### PR TITLE
[Feature] Obfuscate actor total episodes 

### DIFF
--- a/app/src/test/kotlin/com/divinelink/scenepeek/base/storage/DataStorePreferenceStorageTest.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/base/storage/DataStorePreferenceStorageTest.kt
@@ -1,5 +1,6 @@
 package com.divinelink.scenepeek.base.storage
 
+import app.cash.turbine.test
 import com.divinelink.core.datastore.DataStorePreferenceStorage
 import com.divinelink.core.designsystem.theme.Theme
 import com.divinelink.core.model.jellyseerr.JellyseerrAuthMethod
@@ -181,7 +182,7 @@ class DataStorePreferenceStorageTest {
   }
 
   @Test
-  fun `test testJellyseerrSignInMethod`() = runTest {
+  fun `test setJellyseerrSignInMethod`() = runTest {
     storage = DataStorePreferenceStorage(fakeDataStore)
     assertThat(storage.jellyseerrAuthMethod.first()).isEqualTo(null)
 
@@ -202,5 +203,32 @@ class DataStorePreferenceStorageTest {
 
     storage.clearJellyseerrSignInMethod()
     assertThat(storage.jellyseerrAuthMethod.first()).isEqualTo(null)
+  }
+
+  @Test
+  fun `test spoilersObfuscation value`() = runTest {
+    storage = DataStorePreferenceStorage(fakeDataStore)
+
+    storage.spoilersObfuscation.test {
+      assertThat(awaitItem()).isEqualTo(false)
+
+      storage.setSpoilersObfuscation(true)
+
+      assertThat(awaitItem()).isEqualTo(true)
+    }
+  }
+
+  @Test
+  fun `test spoilersObfuscation does not trigger new emissions with the same value`() = runTest {
+    storage = DataStorePreferenceStorage(fakeDataStore)
+
+    storage.spoilersObfuscation.test {
+      assertThat(awaitItem()).isEqualTo(false)
+
+      storage.setSpoilersObfuscation(false)
+      storage.setSpoilersObfuscation(false)
+
+      expectNoEvents()
+    }
   }
 }

--- a/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelRobot.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelRobot.kt
@@ -2,10 +2,12 @@ package com.divinelink.scenepeek.details.ui
 
 import androidx.compose.material3.SnackbarResult
 import androidx.lifecycle.SavedStateHandle
+import com.divinelink.core.domain.credits.SpoilersObfuscationUseCase
 import com.divinelink.core.model.jellyseerr.request.JellyseerrMediaRequest
 import com.divinelink.core.model.media.MediaItem
 import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.testing.MainDispatcherRule
+import com.divinelink.core.testing.storage.FakePreferenceStorage
 import com.divinelink.core.testing.usecase.FakeRequestMediaUseCase
 import com.divinelink.feature.details.media.ui.DetailsViewModel
 import com.divinelink.feature.details.media.ui.DetailsViewState
@@ -32,6 +34,10 @@ class DetailsViewModelRobot {
   private val fakeDeleteRatingUseCase = FakeDeleteRatingUseCase()
   private val fakeAddToWatchListUseCase = FakeAddToWatchlistUseCase()
   private val fakeRequestMediaUseCase = FakeRequestMediaUseCase()
+  private val spoilersObfuscationUseCase = SpoilersObfuscationUseCase(
+    preferenceStorage = FakePreferenceStorage(),
+    dispatcherProvider = mainDispatcherRule.testDispatcher,
+  )
 
   fun buildViewModel(
     id: Int,
@@ -44,6 +50,7 @@ class DetailsViewModelRobot {
       deleteRatingUseCase = fakeDeleteRatingUseCase.mock,
       addToWatchlistUseCase = fakeAddToWatchListUseCase.mock,
       requestMediaUseCase = fakeRequestMediaUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
       savedStateHandle = SavedStateHandle(
         mapOf(
           "id" to id,
@@ -102,6 +109,10 @@ class DetailsViewModelRobot {
     viewModel.onRequestMedia(seasons)
   }
 
+  fun onObfuscateSpoilers() = apply {
+    viewModel.onObfuscateSpoilers()
+  }
+
   fun consumeSnackbar() = apply {
     viewModel.consumeSnackbarMessage()
   }
@@ -109,6 +120,8 @@ class DetailsViewModelRobot {
   fun consumeNavigation() = apply {
     viewModel.consumeNavigateToLogin()
   }
+
+  // Mock Functions
 
   fun mockMarkAsFavoriteUseCase(
     media: MediaItem.Media,
@@ -137,4 +150,9 @@ class DetailsViewModelRobot {
       response = response,
     )
   }
+
+  suspend fun mockSpoilersObfuscation(obfuscated: Boolean) = apply {
+    spoilersObfuscationUseCase.setSpoilersObfuscation(obfuscated)
+  }
+  // End Mock Functions
 }

--- a/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelTest.kt
@@ -1126,4 +1126,35 @@ class DetailsViewModelTest {
         ),
       )
   }
+
+  @Test
+  fun `test obfuscateSpoilers with initially hidden should show them`() = runTest {
+    testRobot
+      .mockFetchMediaDetails(
+        response = defaultDetails(MediaDetailsResult.DetailsSuccess(tvDetails)),
+      )
+      .mockSpoilersObfuscation(false)
+      .buildViewModel(mediaId, MediaType.TV)
+      .assertViewState(
+        DetailsViewState(
+          mediaType = MediaType.TV,
+          mediaId = mediaId,
+          isLoading = false,
+          userDetails = AccountMediaDetailsFactory.NotRated(),
+          mediaDetails = tvDetails,
+          spoilersObfuscated = false,
+        ),
+      )
+      .onObfuscateSpoilers()
+      .assertViewState(
+        DetailsViewState(
+          mediaType = MediaType.TV,
+          mediaId = mediaId,
+          isLoading = false,
+          userDetails = AccountMediaDetailsFactory.NotRated(),
+          mediaDetails = tvDetails,
+          spoilersObfuscated = true,
+        ),
+      )
+  }
 }

--- a/app/src/test/kotlin/com/divinelink/scenepeek/ui/MovieAppTest.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/ui/MovieAppTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
 import androidx.lifecycle.SavedStateHandle
+import com.divinelink.core.domain.credits.SpoilersObfuscationUseCase
 import com.divinelink.core.testing.ComposeTest
 import com.divinelink.core.testing.MainDispatcherRule
 import com.divinelink.core.testing.factories.model.details.MediaDetailsFactory
@@ -21,6 +22,7 @@ import com.divinelink.core.testing.setContentWithTheme
 import com.divinelink.core.testing.usecase.FakeFetchWatchlistUseCase
 import com.divinelink.core.testing.usecase.FakeObserveSessionUseCase
 import com.divinelink.core.testing.usecase.FakeRequestMediaUseCase
+import com.divinelink.core.testing.usecase.TestSpoilersObfuscationUseCase
 import com.divinelink.core.ui.TestTags
 import com.divinelink.feature.details.media.ui.DetailsViewModel
 import com.divinelink.feature.details.media.ui.MediaDetailsResult
@@ -73,6 +75,7 @@ class MovieAppTest : ComposeTest() {
   private lateinit var deleteRatingUseCase: FakeDeleteRatingUseCase
   private lateinit var addToWatchlistUseCase: FakeAddToWatchlistUseCase
   private lateinit var requestMediaUseCase: FakeRequestMediaUseCase
+  private lateinit var spoilersObfuscationUseCase: SpoilersObfuscationUseCase
 
   @BeforeTest
   fun setUp() {
@@ -92,6 +95,7 @@ class MovieAppTest : ComposeTest() {
     deleteRatingUseCase = FakeDeleteRatingUseCase()
     addToWatchlistUseCase = FakeAddToWatchlistUseCase()
     requestMediaUseCase = FakeRequestMediaUseCase()
+    spoilersObfuscationUseCase = TestSpoilersObfuscationUseCase().useCase()
 
     startKoin {
       androidContext(composeTestRule.activity)
@@ -265,6 +269,7 @@ class MovieAppTest : ComposeTest() {
         deleteRatingUseCase = deleteRatingUseCase.mock,
         addToWatchlistUseCase = addToWatchlistUseCase.mock,
         requestMediaUseCase = requestMediaUseCase.mock,
+        spoilersObfuscationUseCase = spoilersObfuscationUseCase,
         savedStateHandle = SavedStateHandle(
           mapOf(
             "id" to 1,

--- a/app/src/test/kotlin/com/divinelink/ui/details/DetailsContentTest.kt
+++ b/app/src/test/kotlin/com/divinelink/ui/details/DetailsContentTest.kt
@@ -58,6 +58,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -89,6 +90,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -115,6 +117,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -142,6 +145,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -182,6 +186,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -226,6 +231,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -253,6 +259,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -288,6 +295,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -320,6 +328,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -356,6 +365,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -402,6 +412,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -448,6 +459,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -478,6 +490,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -509,6 +522,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
 
@@ -537,6 +551,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
     composeTestRule
@@ -574,6 +589,7 @@ class DetailsContentTest : ComposeTest() {
         requestMedia = {},
         viewAllCreditsClicked = {},
         onPersonClick = {},
+        onObfuscateSpoilers = {},
       )
     }
     composeTestRule
@@ -590,6 +606,86 @@ class DetailsContentTest : ComposeTest() {
       .performClick()
 
     composeTestRule.onNodeWithTag(TestTags.Dialogs.REQUEST_MOVIE_DIALOG).assertIsDisplayed()
+  }
+
+  @Test
+  fun `test on obfuscate spoilers when initial is shown`() {
+    var hasClickedObfuscateSpoilers = false
+    setContentWithTheme {
+      DetailsContent(
+        viewState = DetailsViewState(
+          mediaId = 0,
+          mediaType = MediaType.MOVIE,
+          mediaDetails = MediaDetailsFactory.FightClub(),
+          menuOptions = listOf(DetailsMenuOptions.OBFUSCATE_SPOILERS),
+          spoilersObfuscated = false,
+        ),
+        onNavigateUp = {},
+        onMarkAsFavoriteClicked = {},
+        onSimilarMovieClicked = {},
+        onConsumeSnackbar = {},
+        onAddRateClicked = {},
+        onAddToWatchlistClicked = {},
+        requestMedia = {},
+        viewAllCreditsClicked = {},
+        onPersonClick = {},
+        onObfuscateSpoilers = {
+          hasClickedObfuscateSpoilers = true
+        },
+      )
+    }
+
+    with(composeTestRule) {
+      onNodeWithTag(TestTags.Menu.MENU_BUTTON_VERTICAL).performClick()
+      onNodeWithTag(TestTags.Menu.DROPDOWN_MENU).assertIsDisplayed()
+      onNodeWithTag(
+        TestTags.Menu.MENU_ITEM.format(getString(uiR.string.core_ui_hide_total_episodes_item)),
+      )
+        .assertIsDisplayed()
+        .performClick()
+    }
+
+    assertThat(hasClickedObfuscateSpoilers).isTrue()
+  }
+
+  @Test
+  fun `test on obfuscate spoilers when initially is hidden`() {
+    var hasClickedObfuscateSpoilers = false
+    setContentWithTheme {
+      DetailsContent(
+        viewState = DetailsViewState(
+          mediaId = 0,
+          mediaType = MediaType.MOVIE,
+          mediaDetails = MediaDetailsFactory.FightClub(),
+          menuOptions = listOf(DetailsMenuOptions.OBFUSCATE_SPOILERS),
+          spoilersObfuscated = true,
+        ),
+        onNavigateUp = {},
+        onMarkAsFavoriteClicked = {},
+        onSimilarMovieClicked = {},
+        onConsumeSnackbar = {},
+        onAddRateClicked = {},
+        onAddToWatchlistClicked = {},
+        requestMedia = {},
+        viewAllCreditsClicked = {},
+        onPersonClick = {},
+        onObfuscateSpoilers = {
+          hasClickedObfuscateSpoilers = true
+        },
+      )
+    }
+
+    with(composeTestRule) {
+      onNodeWithTag(TestTags.Menu.MENU_BUTTON_VERTICAL).performClick()
+      onNodeWithTag(TestTags.Menu.DROPDOWN_MENU).assertIsDisplayed()
+      onNodeWithTag(
+        TestTags.Menu.MENU_ITEM.format(getString(uiR.string.core_ui_show_total_episodes_item)),
+      )
+        .assertIsDisplayed()
+        .performClick()
+    }
+
+    assertThat(hasClickedObfuscateSpoilers).isTrue()
   }
 
   private val reviews = ReviewFactory.ReviewList()

--- a/app/src/test/kotlin/com/divinelink/ui/details/DetailsScreenTest.kt
+++ b/app/src/test/kotlin/com/divinelink/ui/details/DetailsScreenTest.kt
@@ -22,6 +22,7 @@ import com.divinelink.core.testing.getString
 import com.divinelink.core.testing.navigator.FakeDestinationsNavigator
 import com.divinelink.core.testing.setContentWithTheme
 import com.divinelink.core.testing.usecase.FakeRequestMediaUseCase
+import com.divinelink.core.testing.usecase.TestSpoilersObfuscationUseCase
 import com.divinelink.core.ui.R
 import com.divinelink.core.ui.TestTags
 import com.divinelink.factories.details.domain.model.account.AccountMediaDetailsFactory
@@ -45,17 +46,19 @@ import com.divinelink.feature.details.R as detailsR
 
 class DetailsScreenTest : ComposeTest() {
 
+  private val getMovieDetailsUseCase = FakeGetMediaDetailsUseCase()
+  private val markAsFavoriteUseCase = FakeMarkAsFavoriteUseCase()
+  private val fetchAccountMediaDetailsUseCase = FakeFetchAccountMediaDetailsUseCase()
+  private val submitRateUseCase = FakeSubmitRatingUseCase()
+  private val deleteRatingUseCase = FakeDeleteRatingUseCase()
+  private val addToWatchlistUseCase = FakeAddToWatchlistUseCase()
+  private val requestMediaUseCase = FakeRequestMediaUseCase()
+  private val spoilersObfuscationUseCase = TestSpoilersObfuscationUseCase().useCase()
+
+  private val destinationsNavigator = FakeDestinationsNavigator()
+
   @Test
   fun navigateToAnotherDetailsScreen() {
-    val getMovieDetailsUseCase = FakeGetMediaDetailsUseCase()
-    val markAsFavoriteUseCase = FakeMarkAsFavoriteUseCase()
-    val fetchAccountMediaDetailsUseCase = FakeFetchAccountMediaDetailsUseCase()
-    val submitRateUseCase = FakeSubmitRatingUseCase()
-    val deleteRatingUseCase = FakeDeleteRatingUseCase()
-    val addToWatchlistUseCase = FakeAddToWatchlistUseCase()
-    val requestMediaUseCase = FakeRequestMediaUseCase()
-    val destinationsNavigator = FakeDestinationsNavigator()
-
     destinationsNavigator.navigate(
       direction = DetailsScreenDestination(
         DetailsNavArguments(
@@ -99,6 +102,7 @@ class DetailsScreenTest : ComposeTest() {
           deleteRatingUseCase = deleteRatingUseCase.mock,
           addToWatchlistUseCase = addToWatchlistUseCase.mock,
           requestMediaUseCase = requestMediaUseCase.mock,
+          spoilersObfuscationUseCase = spoilersObfuscationUseCase,
           savedStateHandle = SavedStateHandle(
             mapOf(
               "id" to 0,
@@ -159,14 +163,6 @@ class DetailsScreenTest : ComposeTest() {
 
   @Test
   fun `test rate dialog is visible when your rating is clicked`() = runTest {
-    val getMovieDetailsUseCase = FakeGetMediaDetailsUseCase()
-    val markAsFavoriteUseCase = FakeMarkAsFavoriteUseCase()
-    val submitRateUseCase = FakeSubmitRatingUseCase()
-    val deleteRatingUseCase = FakeDeleteRatingUseCase()
-    val addToWatchlistUseCase = FakeAddToWatchlistUseCase()
-    val requestMediaUseCase = FakeRequestMediaUseCase()
-    val destinationsNavigator = FakeDestinationsNavigator()
-
     getMovieDetailsUseCase.mockFetchMediaDetails(
       response = flowOf(
         Result.success(
@@ -180,7 +176,7 @@ class DetailsScreenTest : ComposeTest() {
           ),
         ),
 
-      ),
+        ),
     )
 
     val viewModel = DetailsViewModel(
@@ -190,6 +186,7 @@ class DetailsScreenTest : ComposeTest() {
       deleteRatingUseCase = deleteRatingUseCase.mock,
       addToWatchlistUseCase = addToWatchlistUseCase.mock,
       requestMediaUseCase = requestMediaUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
       savedStateHandle = SavedStateHandle(
         mapOf(
           "id" to 0,
@@ -220,15 +217,6 @@ class DetailsScreenTest : ComposeTest() {
 
   @Test
   fun `test rate dialog onSubmitRate`() = runTest {
-    val getMovieDetailsUseCase = FakeGetMediaDetailsUseCase()
-    val markAsFavoriteUseCase = FakeMarkAsFavoriteUseCase()
-    val fetchAccountMediaDetailsUseCase = FakeFetchAccountMediaDetailsUseCase()
-    val submitRateUseCase = FakeSubmitRatingUseCase()
-    val deleteRatingUseCase = FakeDeleteRatingUseCase()
-    val addToWatchlistUseCase = FakeAddToWatchlistUseCase()
-    val requestMediaUseCase = FakeRequestMediaUseCase()
-    val destinationsNavigator = FakeDestinationsNavigator()
-
     fetchAccountMediaDetailsUseCase.mockFetchAccountDetails(
       response = flowOf(Result.success(AccountMediaDetailsFactory.NotRated())),
     )
@@ -254,6 +242,7 @@ class DetailsScreenTest : ComposeTest() {
       deleteRatingUseCase = deleteRatingUseCase.mock,
       addToWatchlistUseCase = addToWatchlistUseCase.mock,
       requestMediaUseCase = requestMediaUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
       savedStateHandle = SavedStateHandle(
         mapOf(
           "id" to 0,
@@ -307,14 +296,6 @@ class DetailsScreenTest : ComposeTest() {
 
   @Test
   fun `test navigate to credits screen with tv credits`() {
-    val getMovieDetailsUseCase = FakeGetMediaDetailsUseCase()
-    val markAsFavoriteUseCase = FakeMarkAsFavoriteUseCase()
-    val submitRateUseCase = FakeSubmitRatingUseCase()
-    val deleteRatingUseCase = FakeDeleteRatingUseCase()
-    val addToWatchlistUseCase = FakeAddToWatchlistUseCase()
-    val requestMediaUseCase = FakeRequestMediaUseCase()
-    val destinationsNavigator = FakeDestinationsNavigator()
-
     // Initial navigation to Details screen
     destinationsNavigator.navigate(
       direction = DetailsScreenDestination(
@@ -363,6 +344,7 @@ class DetailsScreenTest : ComposeTest() {
           deleteRatingUseCase = deleteRatingUseCase.mock,
           addToWatchlistUseCase = addToWatchlistUseCase.mock,
           requestMediaUseCase = requestMediaUseCase.mock,
+          spoilersObfuscationUseCase = spoilersObfuscationUseCase,
           savedStateHandle = SavedStateHandle(
             mapOf(
               "id" to 2316,
@@ -406,14 +388,6 @@ class DetailsScreenTest : ComposeTest() {
 
   @Test
   fun `test viewAll credits does not exist without tv credits`() {
-    val getMovieDetailsUseCase = FakeGetMediaDetailsUseCase()
-    val markAsFavoriteUseCase = FakeMarkAsFavoriteUseCase()
-    val submitRateUseCase = FakeSubmitRatingUseCase()
-    val deleteRatingUseCase = FakeDeleteRatingUseCase()
-    val addToWatchlistUseCase = FakeAddToWatchlistUseCase()
-    val requestMediaUseCase = FakeRequestMediaUseCase()
-    val destinationsNavigator = FakeDestinationsNavigator()
-
     // Initial navigation to Details screen
     destinationsNavigator.navigate(
       direction = DetailsScreenDestination(
@@ -447,6 +421,7 @@ class DetailsScreenTest : ComposeTest() {
           deleteRatingUseCase = deleteRatingUseCase.mock,
           addToWatchlistUseCase = addToWatchlistUseCase.mock,
           requestMediaUseCase = requestMediaUseCase.mock,
+          spoilersObfuscationUseCase = spoilersObfuscationUseCase,
           savedStateHandle = SavedStateHandle(
             mapOf(
               "id" to 2316,

--- a/core/datastore/src/main/java/com/divinelink/core/datastore/PreferenceStorage.kt
+++ b/core/datastore/src/main/java/com/divinelink/core/datastore/PreferenceStorage.kt
@@ -40,8 +40,8 @@ interface PreferenceStorage {
   suspend fun setEncryptedPreferences(value: String)
   val encryptedPreferences: Flow<String?>
 
-  suspend fun setSeriesEpisodeObfuscation(isEnabled: Boolean)
-  val isSeriesEpisodeObfuscationEnabled: Flow<Boolean>
+  suspend fun setSpoilersObfuscation(isEnabled: Boolean)
+  val spoilersObfuscation: Flow<Boolean>
 
   suspend fun clearToken()
   suspend fun setToken(token: String)
@@ -131,13 +131,13 @@ class DataStorePreferenceStorage(private val dataStore: DataStore<Preferences>) 
     preferences[PREF_ENCRYPTED_SHARED_PREFS]
   }
 
-  override suspend fun setSeriesEpisodeObfuscation(isEnabled: Boolean) {
+  override suspend fun setSpoilersObfuscation(isEnabled: Boolean) {
     dataStore.edit {
       it[PREF_SERIES_TOTAL_EPISODES_OBFUSCATION] = isEnabled
     }
   }
 
-  override val isSeriesEpisodeObfuscationEnabled = dataStore.data.mapLatest {
+  override val spoilersObfuscation = dataStore.data.mapLatest {
     it[PREF_SERIES_TOTAL_EPISODES_OBFUSCATION] ?: false
   }
 

--- a/core/datastore/src/main/java/com/divinelink/core/datastore/PreferenceStorage.kt
+++ b/core/datastore/src/main/java/com/divinelink/core/datastore/PreferenceStorage.kt
@@ -15,10 +15,12 @@ import com.divinelink.core.datastore.DataStorePreferenceStorage.PreferencesKeys.
 import com.divinelink.core.datastore.DataStorePreferenceStorage.PreferencesKeys.PREF_MATERIAL_YOU
 import com.divinelink.core.datastore.DataStorePreferenceStorage.PreferencesKeys.PREF_REQUEST_TOKEN
 import com.divinelink.core.datastore.DataStorePreferenceStorage.PreferencesKeys.PREF_SELECTED_THEME
+import com.divinelink.core.datastore.DataStorePreferenceStorage.PreferencesKeys.PREF_SERIES_TOTAL_EPISODES_OBFUSCATION
 import com.divinelink.core.designsystem.theme.Theme
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import timber.log.Timber
 
 interface PreferenceStorage {
@@ -37,6 +39,9 @@ interface PreferenceStorage {
 
   suspend fun setEncryptedPreferences(value: String)
   val encryptedPreferences: Flow<String?>
+
+  suspend fun setSeriesEpisodeObfuscation(isEnabled: Boolean)
+  val isSeriesEpisodeObfuscationEnabled: Flow<Boolean>
 
   suspend fun clearToken()
   suspend fun setToken(token: String)
@@ -70,6 +75,10 @@ class DataStorePreferenceStorage(private val dataStore: DataStore<Preferences>) 
     val PREF_SELECTED_THEME = stringPreferencesKey("settings.theme")
     val PREF_MATERIAL_YOU = booleanPreferencesKey("settings.material.you")
     val PREF_BLACK_BACKGROUNDS = booleanPreferencesKey("settings.black.backgrounds")
+
+    val PREF_SERIES_TOTAL_EPISODES_OBFUSCATION = booleanPreferencesKey(
+      "settings.series.episode.obfuscation",
+    )
 
     val PREF_ACCOUNT_ID = stringPreferencesKey("account.id")
 
@@ -120,6 +129,16 @@ class DataStorePreferenceStorage(private val dataStore: DataStore<Preferences>) 
 
   override val encryptedPreferences = dataStore.data.map { preferences ->
     preferences[PREF_ENCRYPTED_SHARED_PREFS]
+  }
+
+  override suspend fun setSeriesEpisodeObfuscation(isEnabled: Boolean) {
+    dataStore.edit {
+      it[PREF_SERIES_TOTAL_EPISODES_OBFUSCATION] = isEnabled
+    }
+  }
+
+  override val isSeriesEpisodeObfuscationEnabled = dataStore.data.mapLatest {
+    it[PREF_SERIES_TOTAL_EPISODES_OBFUSCATION] ?: false
   }
 
   override suspend fun clearToken() {

--- a/core/datastore/src/main/java/com/divinelink/core/datastore/PreferenceStorage.kt
+++ b/core/datastore/src/main/java/com/divinelink/core/datastore/PreferenceStorage.kt
@@ -139,7 +139,7 @@ class DataStorePreferenceStorage(private val dataStore: DataStore<Preferences>) 
 
   override val spoilersObfuscation = dataStore.data.mapLatest {
     it[PREF_SERIES_TOTAL_EPISODES_OBFUSCATION] ?: false
-  }
+  }.distinctUntilChanged()
 
   override suspend fun clearToken() {
     dataStore.edit {

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/GetDetailsActionItemsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/GetDetailsActionItemsUseCase.kt
@@ -5,24 +5,22 @@ import com.divinelink.core.commons.domain.FlowUseCase
 import com.divinelink.core.datastore.PreferenceStorage
 import com.divinelink.core.model.details.DetailActionItem
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.mapLatest
 
 class GetDetailsActionItemsUseCase(
   private val storage: PreferenceStorage,
   val dispatcher: DispatcherProvider,
 ) : FlowUseCase<Unit, List<DetailActionItem>>(dispatcher.io) {
 
-  override fun execute(parameters: Unit): Flow<Result<List<DetailActionItem>>> = combine(
-    storage.jellyseerrAccount,
-  ) { account ->
-
-    val menuItems = buildList {
-      add(DetailActionItem.RATE)
-      add(DetailActionItem.WATCHLIST)
-      account.firstOrNull()?.let {
-        add(DetailActionItem.REQUEST)
+  override fun execute(parameters: Unit): Flow<Result<List<DetailActionItem>>> =
+    storage.jellyseerrAccount.mapLatest { account ->
+      val menuItems = buildList {
+        add(DetailActionItem.RATE)
+        add(DetailActionItem.WATCHLIST)
+        account?.firstOrNull()?.let {
+          add(DetailActionItem.REQUEST)
+        }
       }
+      Result.success(menuItems)
     }
-    Result.success(menuItems)
-  }
 }

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCase.kt
@@ -3,14 +3,18 @@ package com.divinelink.core.domain
 import com.divinelink.core.commons.domain.DispatcherProvider
 import com.divinelink.core.commons.domain.FlowUseCase
 import com.divinelink.core.model.details.DetailsMenuOptions
+import com.divinelink.core.model.media.MediaType
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-class GetDropdownMenuItemsUseCase(val dispatcher: DispatcherProvider) :
-  FlowUseCase<Unit, List<DetailsMenuOptions>>(dispatcher.io) {
+class GetDropdownMenuItemsUseCase(dispatcher: DispatcherProvider) :
+  FlowUseCase<MediaType, List<DetailsMenuOptions>>(dispatcher.io) {
 
-  override fun execute(parameters: Unit): Flow<Result<List<DetailsMenuOptions>>> = flow {
+  override fun execute(parameters: MediaType): Flow<Result<List<DetailsMenuOptions>>> = flow {
     val menuItems = buildList {
+      if (parameters == MediaType.TV) {
+        add(DetailsMenuOptions.OBFUSCATE_SPOILERS)
+      }
       add(DetailsMenuOptions.SHARE)
     }
     emit(Result.success(menuItems))

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/credits/EpisodesObfuscationUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/credits/EpisodesObfuscationUseCase.kt
@@ -1,0 +1,22 @@
+package com.divinelink.core.domain.credits
+
+import com.divinelink.core.commons.domain.DispatcherProvider
+import com.divinelink.core.commons.domain.FlowUseCase
+import com.divinelink.core.datastore.PreferenceStorage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapLatest
+
+class EpisodesObfuscationUseCase(
+  private val preferenceStorage: PreferenceStorage,
+  dispatcherProvider: DispatcherProvider,
+) : FlowUseCase<Unit, Boolean>(dispatcherProvider.io) {
+  override fun execute(parameters: Unit): Flow<Result<Boolean>> = preferenceStorage
+    .isSeriesEpisodeObfuscationEnabled
+    .mapLatest { isObfuscated ->
+      Result.success(isObfuscated)
+    }
+
+  suspend fun setEpisodesObfuscation(isObfuscated: Boolean) {
+    preferenceStorage.setSeriesEpisodeObfuscation(isObfuscated)
+  }
+}

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/credits/FetchCreditsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/credits/FetchCreditsUseCase.kt
@@ -1,17 +1,16 @@
 package com.divinelink.core.domain.credits
 
-
+import com.divinelink.core.commons.domain.DispatcherProvider
 import com.divinelink.core.commons.domain.FlowUseCase
 import com.divinelink.core.commons.domain.data
 import com.divinelink.core.data.details.repository.DetailsRepository
 import com.divinelink.core.model.credits.AggregateCredits
-import com.divinelink.core.commons.domain.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class FetchCreditsUseCase(
   private val repository: DetailsRepository,
-  val dispatcher: DispatcherProvider
+  val dispatcher: DispatcherProvider,
 ) : FlowUseCase<Long, AggregateCredits>(dispatcher.io) {
 
   override fun execute(parameters: Long): Flow<Result<AggregateCredits>> = flow {

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/credits/SpoilersObfuscationUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/credits/SpoilersObfuscationUseCase.kt
@@ -6,17 +6,17 @@ import com.divinelink.core.datastore.PreferenceStorage
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapLatest
 
-class EpisodesObfuscationUseCase(
+class SpoilersObfuscationUseCase(
   private val preferenceStorage: PreferenceStorage,
   dispatcherProvider: DispatcherProvider,
 ) : FlowUseCase<Unit, Boolean>(dispatcherProvider.io) {
   override fun execute(parameters: Unit): Flow<Result<Boolean>> = preferenceStorage
-    .isSeriesEpisodeObfuscationEnabled
+    .spoilersObfuscation
     .mapLatest { isObfuscated ->
       Result.success(isObfuscated)
     }
 
-  suspend fun setEpisodesObfuscation(isObfuscated: Boolean) {
-    preferenceStorage.setSeriesEpisodeObfuscation(isObfuscated)
+  suspend fun setSpoilersObfuscation(isObfuscated: Boolean) {
+    preferenceStorage.setSpoilersObfuscation(isObfuscated)
   }
 }

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/di/UseCaseModule.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/di/UseCaseModule.kt
@@ -3,11 +3,12 @@ package com.divinelink.core.domain.di
 import com.divinelink.core.domain.CreateRequestTokenUseCase
 import com.divinelink.core.domain.FetchWatchlistUseCase
 import com.divinelink.core.domain.GetAccountDetailsUseCase
-import com.divinelink.core.domain.GetDropdownMenuItemsUseCase
 import com.divinelink.core.domain.GetDetailsActionItemsUseCase
+import com.divinelink.core.domain.GetDropdownMenuItemsUseCase
 import com.divinelink.core.domain.HandleAuthenticationRequestUseCase
 import com.divinelink.core.domain.MarkAsFavoriteUseCase
 import com.divinelink.core.domain.change.FetchChangesUseCase
+import com.divinelink.core.domain.credits.EpisodesObfuscationUseCase
 import com.divinelink.core.domain.credits.FetchCreditsUseCase
 import com.divinelink.core.domain.details.person.FetchPersonDetailsUseCase
 import com.divinelink.core.domain.jellyseerr.GetJellyseerrAccountDetailsUseCase
@@ -47,4 +48,6 @@ val useCaseModule = module {
   factoryOf(::GetDetailsActionItemsUseCase)
   factoryOf(::HandleAuthenticationRequestUseCase)
   factoryOf(::MarkAsFavoriteUseCase)
+
+  factoryOf(::EpisodesObfuscationUseCase)
 }

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/di/UseCaseModule.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/di/UseCaseModule.kt
@@ -8,7 +8,7 @@ import com.divinelink.core.domain.GetDropdownMenuItemsUseCase
 import com.divinelink.core.domain.HandleAuthenticationRequestUseCase
 import com.divinelink.core.domain.MarkAsFavoriteUseCase
 import com.divinelink.core.domain.change.FetchChangesUseCase
-import com.divinelink.core.domain.credits.EpisodesObfuscationUseCase
+import com.divinelink.core.domain.credits.SpoilersObfuscationUseCase
 import com.divinelink.core.domain.credits.FetchCreditsUseCase
 import com.divinelink.core.domain.details.person.FetchPersonDetailsUseCase
 import com.divinelink.core.domain.jellyseerr.GetJellyseerrAccountDetailsUseCase
@@ -49,5 +49,5 @@ val useCaseModule = module {
   factoryOf(::HandleAuthenticationRequestUseCase)
   factoryOf(::MarkAsFavoriteUseCase)
 
-  factoryOf(::EpisodesObfuscationUseCase)
+  factoryOf(::SpoilersObfuscationUseCase)
 }

--- a/core/domain/src/test/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/divinelink/core/domain/GetDropdownMenuItemsUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.divinelink.core.domain
 
 import com.divinelink.core.model.details.DetailsMenuOptions
+import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.testing.MainDispatcherRule
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
@@ -15,12 +16,27 @@ class GetDropdownMenuItemsUseCaseTest {
   private val testDispatcher = mainDispatcherRule.testDispatcher
 
   @Test
-  fun `test dropdown menu items without jellyseerr account`() = runTest {
+  fun `test dropdown menu items for movie does not include spoilers action`() = runTest {
     val useCase = GetDropdownMenuItemsUseCase(testDispatcher)
 
-    useCase.invoke(Unit).first().let { result ->
+    useCase.invoke(MediaType.MOVIE).first().let { result ->
       assertThat(result.isSuccess).isTrue()
       assertThat(result.getOrNull()).isEqualTo(listOf(DetailsMenuOptions.SHARE))
+    }
+  }
+
+  @Test
+  fun `test dropdown menu items for tv media shows spoiler action`() = runTest {
+    val useCase = GetDropdownMenuItemsUseCase(testDispatcher)
+
+    useCase.invoke(MediaType.TV).first().let { result ->
+      assertThat(result.isSuccess).isTrue()
+      assertThat(result.getOrNull()).isEqualTo(
+        listOf(
+          DetailsMenuOptions.OBFUSCATE_SPOILERS,
+          DetailsMenuOptions.SHARE,
+        ),
+      )
     }
   }
 }

--- a/core/domain/src/test/kotlin/com/divinelink/core/domain/credits/SpoilersObfuscationUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/divinelink/core/domain/credits/SpoilersObfuscationUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.divinelink.core.domain.credits
+
+import app.cash.turbine.test
+import com.divinelink.core.testing.MainDispatcherRule
+import com.divinelink.core.testing.storage.FakePreferenceStorage
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import kotlin.test.Test
+
+class SpoilersObfuscationUseCaseTest {
+
+  @get:Rule
+  val mainDispatcherRule = MainDispatcherRule()
+
+  @Test
+  fun `test spoilers obfuscation with initially hidden spoilers`() = runTest {
+    val useCase = SpoilersObfuscationUseCase(
+      preferenceStorage = FakePreferenceStorage(
+        spoilersObfuscation = false,
+      ),
+      dispatcherProvider = mainDispatcherRule.testDispatcher,
+    )
+
+    useCase.invoke(Unit).test {
+      assertThat(awaitItem()).isEqualTo(Result.success(false))
+      useCase.setSpoilersObfuscation(true)
+      assertThat(awaitItem()).isEqualTo(Result.success(true))
+    }
+  }
+
+  @Test
+  fun `test spoilers obfuscation with initially shown spoilers`() = runTest {
+    val useCase = SpoilersObfuscationUseCase(
+      preferenceStorage = FakePreferenceStorage(
+        spoilersObfuscation = true,
+      ),
+      dispatcherProvider = mainDispatcherRule.testDispatcher,
+    )
+
+    useCase.invoke(Unit).test {
+      assertThat(awaitItem()).isEqualTo(Result.success(true))
+      useCase.setSpoilersObfuscation(false)
+      assertThat(awaitItem()).isEqualTo(Result.success(false))
+    }
+  }
+}

--- a/core/model/src/main/kotlin/com/divinelink/core/model/details/DetailsMenuOptions.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/details/DetailsMenuOptions.kt
@@ -2,4 +2,5 @@ package com.divinelink.core.model.details
 
 enum class DetailsMenuOptions {
   SHARE,
+  OBFUSCATE_SPOILERS
 }

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/storage/FakePreferenceStorage.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/storage/FakePreferenceStorage.kt
@@ -15,6 +15,7 @@ class FakePreferenceStorage(
   jellyseerrAddress: String? = null,
   jellyseerrAccount: String? = null,
   jellyseerrSignInMethod: String? = null,
+  spoilersObfuscation: Boolean = false,
 ) : PreferenceStorage {
 
   private val _selectedTheme = MutableStateFlow(selectedTheme)
@@ -47,7 +48,7 @@ class FakePreferenceStorage(
   private val _jellyseerrAuthMethod = MutableStateFlow(jellyseerrSignInMethod)
   override val jellyseerrAuthMethod: Flow<String?> = _jellyseerrAuthMethod
 
-  private val _spoilersObfuscation = MutableStateFlow(false)
+  private val _spoilersObfuscation = MutableStateFlow(spoilersObfuscation)
   override val spoilersObfuscation: Flow<Boolean> = _spoilersObfuscation
 
   override suspend fun selectTheme(theme: String) {

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/storage/FakePreferenceStorage.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/storage/FakePreferenceStorage.kt
@@ -47,6 +47,9 @@ class FakePreferenceStorage(
   private val _jellyseerrAuthMethod = MutableStateFlow(jellyseerrSignInMethod)
   override val jellyseerrAuthMethod: Flow<String?> = _jellyseerrAuthMethod
 
+  private val _spoilersObfuscation = MutableStateFlow(false)
+  override val spoilersObfuscation: Flow<Boolean> = _spoilersObfuscation
+
   override suspend fun selectTheme(theme: String) {
     _selectedTheme.value = theme
   }
@@ -105,5 +108,9 @@ class FakePreferenceStorage(
 
   override suspend fun setJellyseerrAuthMethod(authMethod: String) {
     _jellyseerrAuthMethod.value = authMethod
+  }
+
+  override suspend fun setSpoilersObfuscation(isEnabled: Boolean) {
+    _spoilersObfuscation.value = isEnabled
   }
 }

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/usecase/TestSpoilersObfuscationUseCase.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/usecase/TestSpoilersObfuscationUseCase.kt
@@ -1,0 +1,17 @@
+package com.divinelink.core.testing.usecase
+
+import com.divinelink.core.domain.credits.SpoilersObfuscationUseCase
+import com.divinelink.core.testing.MainDispatcherRule
+import com.divinelink.core.testing.storage.FakePreferenceStorage
+import org.junit.Rule
+
+class TestSpoilersObfuscationUseCase {
+
+  @get:Rule
+  val mainDispatcherRule = MainDispatcherRule()
+
+  fun useCase(initialValue: Boolean = false) = SpoilersObfuscationUseCase(
+    preferenceStorage = FakePreferenceStorage(spoilersObfuscation = initialValue),
+    dispatcherProvider = mainDispatcherRule.testDispatcher,
+  )
+}

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/DetailsDropdownMenu.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/DetailsDropdownMenu.kt
@@ -20,14 +20,17 @@ import com.divinelink.core.model.details.MediaDetails
 import com.divinelink.core.model.details.Movie
 import com.divinelink.core.model.details.Person
 import com.divinelink.core.model.details.shareUrl
+import com.divinelink.core.ui.components.dropdownmenu.ObfuscateSpoilersMenuItem
 import com.divinelink.core.ui.components.dropdownmenu.ShareMenuItem
 
 @Composable
 fun DetailsDropdownMenu(
   mediaDetails: MediaDetails,
+  spoilersObfuscated: Boolean,
   options: List<DetailsMenuOptions>,
   expanded: Boolean,
   onDismissDropdown: () -> Unit,
+  onObfuscateClick: () -> Unit,
 ) {
   var showShareDialog by remember { mutableStateOf(false) }
 
@@ -54,6 +57,10 @@ fun DetailsDropdownMenu(
             onDismissDropdown()
             showShareDialog = true
           },
+        )
+        DetailsMenuOptions.OBFUSCATE_SPOILERS -> ObfuscateSpoilersMenuItem(
+          obfuscated = spoilersObfuscated,
+          onClick = onObfuscateClick,
         )
       }
     }
@@ -85,9 +92,11 @@ private fun DetailsDropdownMenuPreview() {
           genres = listOf("Thriller", "Drama", "Comedy"),
           runtime = "2h 10m",
         ),
+        spoilersObfuscated = false,
         expanded = true,
         options = DetailsMenuOptions.entries,
         onDismissDropdown = {},
+        onObfuscateClick = {},
       )
     }
   }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/ModifierExtensions.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/ModifierExtensions.kt
@@ -1,0 +1,36 @@
+package com.divinelink.core.ui
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.BlurEffect
+import androidx.compose.ui.graphics.TileMode
+import androidx.compose.ui.graphics.graphicsLayer
+
+/**
+ * Conditionally applies the given [Modifier]s based on the given [condition].
+ *
+ * @param condition The condition to check.
+ * @param ifTrue The [Modifier] to apply if the [condition] is `true`.
+ * @param ifFalse The [Modifier] to apply if the [condition] is `false`.
+ */
+inline fun Modifier.conditional(
+  condition: Boolean,
+  ifTrue: Modifier.() -> Modifier = { this },
+  ifFalse: Modifier.() -> Modifier = { this },
+): Modifier = if (condition) {
+  then(ifTrue(Modifier))
+} else {
+  then(ifFalse(Modifier))
+}
+
+fun Modifier.blurEffect(
+  radiusX: Float = 15f,
+  radiusY: Float = 15f,
+): Modifier = this.then(
+  graphicsLayer {
+    renderEffect = BlurEffect(
+      radiusX = radiusX,
+      radiusY = radiusY,
+      edgeTreatment = TileMode.Clamp,
+    )
+  },
+)

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/TestTags.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/TestTags.kt
@@ -97,7 +97,7 @@ object TestTags {
     const val MENU_BUTTON_VERTICAL = "Menu Button Vertical"
     const val DROPDOWN_MENU = "Dropdown Menu"
     const val MENU_ITEM = "Menu Item %s"
-    const val EPISODES_OBFUSCATION = "Episodes Obfuscation Button"
+    const val SPOILERS_OBFUSCATION = "Spoilers Obfuscation Button"
   }
 
   object Watchlist {

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/TestTags.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/TestTags.kt
@@ -97,6 +97,7 @@ object TestTags {
     const val MENU_BUTTON_VERTICAL = "Menu Button Vertical"
     const val DROPDOWN_MENU = "Dropdown Menu"
     const val MENU_ITEM = "Menu Item %s"
+    const val EPISODES_OBFUSCATION = "Episodes Obfuscation Button"
   }
 
   object Watchlist {

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/IconButtonWithTooltip.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/IconButtonWithTooltip.kt
@@ -1,0 +1,39 @@
+package com.divinelink.core.ui.components
+
+import androidx.annotation.StringRes
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.RichTooltip
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TooltipDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun IconButtonWithTooltip(
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  @StringRes tooltipText: Int,
+  icon: @Composable () -> Unit,
+) {
+  TooltipBox(
+    positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
+    tooltip = {
+      RichTooltip {
+        Text(stringResource(tooltipText))
+      }
+    },
+    state = rememberTooltipState(),
+  ) {
+    IconButton(
+      modifier = modifier,
+      onClick = onClick,
+    ) {
+      icon()
+    }
+  }
+}

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/IconButtonWithTooltip.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/IconButtonWithTooltip.kt
@@ -1,8 +1,10 @@
 package com.divinelink.core.ui.components
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RichTooltip
 import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipBox
@@ -11,6 +13,7 @@ import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import com.divinelink.core.designsystem.theme.dimensions
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -24,7 +27,10 @@ fun IconButtonWithTooltip(
     positionProvider = TooltipDefaults.rememberPlainTooltipPositionProvider(),
     tooltip = {
       RichTooltip {
-        Text(stringResource(tooltipText))
+        Text(
+          modifier = Modifier.padding(MaterialTheme.dimensions.keyline_8),
+          text = stringResource(tooltipText),
+        )
       }
     },
     state = rememberTooltipState(),

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/ObfuscateSpoilersButton.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/ObfuscateSpoilersButton.kt
@@ -1,8 +1,8 @@
 package com.divinelink.core.ui.components
 
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
@@ -11,24 +11,34 @@ import com.divinelink.core.ui.R
 import com.divinelink.core.ui.TestTags
 
 @Composable
-fun ObfuscateTotalEpisodesButton(
-  episodesObfuscated: Boolean,
+fun ObfuscateSpoilersButton(
+  obfuscated: Boolean,
   onClick: () -> Unit,
 ) {
-  IconButton(
-    modifier = Modifier.testTag(TestTags.Menu.EPISODES_OBFUSCATION),
+  val tooltipText = remember(obfuscated) {
+    if (obfuscated) {
+      R.string.core_ui_show_spoilers_tooltip
+    } else {
+      R.string.core_ui_hide_spoilers_tooltip
+    }
+  }
+
+  IconButtonWithTooltip(
     onClick = onClick,
+    modifier = Modifier.testTag(TestTags.Menu.SPOILERS_OBFUSCATION),
+    tooltipText = tooltipText,
   ) {
-    if (episodesObfuscated) {
+    if (obfuscated) {
       Icon(
         painter = painterResource(id = R.drawable.core_ui_eye_off),
-        contentDescription = stringResource(R.string.core_ui_hidden_total_episodes_button),
+        contentDescription = stringResource(R.string.core_ui_hidden_spoilers_button),
       )
     } else {
       Icon(
         painter = painterResource(R.drawable.core_ui_eye),
-        contentDescription = stringResource(R.string.core_ui_visible_total_episodes_button),
+        contentDescription = stringResource(R.string.core_ui_visible_spoilers_button),
       )
     }
   }
 }
+

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/ObfuscateSpoilersButton.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/ObfuscateSpoilersButton.kt
@@ -41,4 +41,3 @@ fun ObfuscateSpoilersButton(
     }
   }
 }
-

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/ObfuscateTotalEpisodesButton.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/ObfuscateTotalEpisodesButton.kt
@@ -1,0 +1,34 @@
+package com.divinelink.core.ui.components
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import com.divinelink.core.ui.R
+import com.divinelink.core.ui.TestTags
+
+@Composable
+fun ObfuscateTotalEpisodesButton(
+  episodesObfuscated: Boolean,
+  onClick: () -> Unit,
+) {
+  IconButton(
+    modifier = Modifier.testTag(TestTags.Menu.EPISODES_OBFUSCATION),
+    onClick = onClick,
+  ) {
+    if (episodesObfuscated) {
+      Icon(
+        painter = painterResource(id = R.drawable.core_ui_eye_off),
+        contentDescription = stringResource(R.string.core_ui_hidden_total_episodes_button),
+      )
+    } else {
+      Icon(
+        painter = painterResource(R.drawable.core_ui_eye),
+        contentDescription = stringResource(R.string.core_ui_visible_total_episodes_button),
+      )
+    }
+  }
+}

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/cast/CastList.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/cast/CastList.kt
@@ -32,6 +32,7 @@ fun CastList(
   onPersonClick: (Person) -> Unit,
   onViewAllClick: () -> Unit,
   viewAllVisible: Boolean = true,
+  obfuscateEpisodes: Boolean = false,
 ) {
   Column(
     modifier = Modifier
@@ -77,7 +78,11 @@ fun CastList(
           items = cast,
           key = { it.id },
         ) {
-          CreditsItemCard(person = it, onPersonClick = onPersonClick)
+          CreditsItemCard(
+            person = it,
+            onPersonClick = onPersonClick,
+            obfuscateEpisodes = obfuscateEpisodes,
+          )
         }
       }
     }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/cast/CreditsItemCard.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/cast/CreditsItemCard.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.divinelink.core.designsystem.theme.AppTheme
@@ -31,6 +30,7 @@ import com.divinelink.core.model.credits.PersonRole
 import com.divinelink.core.model.details.Person
 import com.divinelink.core.model.person.Gender
 import com.divinelink.core.ui.MovieImage
+import com.divinelink.core.ui.Previews
 import com.divinelink.core.ui.R
 import com.divinelink.core.ui.blurEffect
 import com.divinelink.core.ui.conditional
@@ -113,11 +113,11 @@ fun CreditsItemCard(
   }
 }
 
-@Preview
+@Previews
 @Composable
 fun CreditsItemCardPreview(@PreviewParameter(PersonParameterProvider::class) person: Person) {
-  Surface {
-    AppTheme {
+  AppTheme {
+    Surface {
       Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_8)) {
         CreditsItemCard(
           person = person,

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/cast/CreditsItemCard.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/cast/CreditsItemCard.kt
@@ -1,6 +1,8 @@
 package com.divinelink.core.ui.components.details.cast
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -30,6 +32,8 @@ import com.divinelink.core.model.details.Person
 import com.divinelink.core.model.person.Gender
 import com.divinelink.core.ui.MovieImage
 import com.divinelink.core.ui.R
+import com.divinelink.core.ui.blurEffect
+import com.divinelink.core.ui.conditional
 import com.divinelink.core.ui.provider.PersonParameterProvider
 
 @Composable
@@ -37,6 +41,7 @@ fun CreditsItemCard(
   modifier: Modifier = Modifier,
   person: Person,
   onPersonClick: (Person) -> Unit,
+  isObfuscated: Boolean = false,
 ) {
   Card(
     shape = PopularMovieItemShape,
@@ -90,7 +95,11 @@ fun CreditsItemCard(
             Text(
               modifier = Modifier
                 .padding(horizontal = MaterialTheme.dimensions.keyline_8)
-                .padding(bottom = MaterialTheme.dimensions.keyline_4),
+                .padding(bottom = MaterialTheme.dimensions.keyline_4)
+                .conditional(
+                  condition = isObfuscated,
+                  ifTrue = { blurEffect() },
+                ),
               text = stringResource(R.string.core_ui_episode_count, episodes),
               maxLines = 1,
               style = MaterialTheme.typography.bodySmall,
@@ -109,10 +118,19 @@ fun CreditsItemCard(
 fun CreditsItemCardPreview(@PreviewParameter(PersonParameterProvider::class) person: Person) {
   Surface {
     AppTheme {
-      CreditsItemCard(
-        person = person,
-        onPersonClick = {},
-      )
+      Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_8)) {
+        CreditsItemCard(
+          person = person,
+          onPersonClick = {},
+          isObfuscated = false,
+        )
+
+        CreditsItemCard(
+          person = person,
+          onPersonClick = {},
+          isObfuscated = true,
+        )
+      }
     }
   }
 }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/cast/CreditsItemCard.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/cast/CreditsItemCard.kt
@@ -41,7 +41,7 @@ fun CreditsItemCard(
   modifier: Modifier = Modifier,
   person: Person,
   onPersonClick: (Person) -> Unit,
-  isObfuscated: Boolean = false,
+  obfuscateEpisodes: Boolean = false,
 ) {
   Card(
     shape = PopularMovieItemShape,
@@ -97,7 +97,7 @@ fun CreditsItemCard(
                 .padding(horizontal = MaterialTheme.dimensions.keyline_8)
                 .padding(bottom = MaterialTheme.dimensions.keyline_4)
                 .conditional(
-                  condition = isObfuscated,
+                  condition = obfuscateEpisodes,
                   ifTrue = { blurEffect() },
                 ),
               text = stringResource(R.string.core_ui_episode_count, episodes),
@@ -122,13 +122,13 @@ fun CreditsItemCardPreview(@PreviewParameter(PersonParameterProvider::class) per
         CreditsItemCard(
           person = person,
           onPersonClick = {},
-          isObfuscated = false,
+          obfuscateEpisodes = false,
         )
 
         CreditsItemCard(
           person = person,
           onPersonClick = {},
-          isObfuscated = true,
+          obfuscateEpisodes = true,
         )
       }
     }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/dropdownmenu/ObfuscateSpoilersMenuItem.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/dropdownmenu/ObfuscateSpoilersMenuItem.kt
@@ -1,0 +1,75 @@
+package com.divinelink.core.ui.components.dropdownmenu
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import com.divinelink.core.designsystem.theme.AppTheme
+import com.divinelink.core.designsystem.theme.dimensions
+import com.divinelink.core.ui.Previews
+import com.divinelink.core.ui.R
+import com.divinelink.core.ui.TestTags
+
+@Composable
+fun ObfuscateSpoilersMenuItem(
+  obfuscated: Boolean,
+  onClick: () -> Unit,
+) {
+  val textRes = remember(obfuscated) {
+    if (obfuscated) {
+      R.string.core_ui_show_total_episodes_item
+    } else {
+      R.string.core_ui_hide_total_episodes_item
+    }
+  }
+
+  DropdownMenuItem(
+    modifier = Modifier.testTag(
+      TestTags.Menu.MENU_ITEM.format(stringResource(id = textRes)),
+    ),
+    text = { Text(text = stringResource(id = textRes)) },
+    leadingIcon = {
+      if (obfuscated) {
+        Icon(
+          painter = painterResource(R.drawable.core_ui_eye),
+          contentDescription = stringResource(R.string.core_ui_visible_spoilers_button),
+        )
+      } else {
+        Icon(
+          painter = painterResource(id = R.drawable.core_ui_eye_off),
+          contentDescription = stringResource(R.string.core_ui_hidden_spoilers_button),
+        )
+      }
+    },
+    onClick = onClick,
+  )
+}
+
+@Previews
+@Composable
+fun ObfuscateTotalEpisodesMenuItemPreview() {
+  AppTheme {
+    Surface {
+      Column(verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_8)) {
+        ObfuscateSpoilersMenuItem(
+          obfuscated = false,
+          onClick = {},
+        )
+
+        ObfuscateSpoilersMenuItem(
+          obfuscated = true,
+          onClick = {},
+        )
+      }
+    }
+  }
+}

--- a/core/ui/src/main/res/drawable/core_ui_eye.xml
+++ b/core/ui/src/main/res/drawable/core_ui_eye.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#00000000"
+      android:pathData="M1,12s4,-8 11,-8 11,8 11,8 -4,8 -11,8 -11,-8 -11,-8z"
+      android:strokeWidth="2"
+      android:strokeColor="@color/colorSurface"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round" />
+  <path
+      android:fillColor="#00000000"
+      android:pathData="M12,12m-3,0a3,3 0,1 1,6 0a3,3 0,1 1,-6 0"
+      android:strokeWidth="2"
+      android:strokeColor="@color/colorSurface"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round" />
+</vector>

--- a/core/ui/src/main/res/drawable/core_ui_eye_off.xml
+++ b/core/ui/src/main/res/drawable/core_ui_eye_off.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#00000000"
+      android:pathData="M17.94,17.94A10.07,10.07 0,0 1,12 20c-7,0 -11,-8 -11,-8a18.45,18.45 0,0 1,5.06 -5.94M9.9,4.24A9.12,9.12 0,0 1,12 4c7,0 11,8 11,8a18.5,18.5 0,0 1,-2.16 3.19m-6.72,-1.07a3,3 0,1 1,-4.24 -4.24"
+      android:strokeWidth="2"
+      android:strokeColor="@color/colorSurface"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round" />
+  <path
+      android:fillColor="#00000000"
+      android:pathData="M1,1L23,23"
+      android:strokeWidth="2"
+      android:strokeColor="@color/colorSurface"
+      android:strokeLineCap="round"
+      android:strokeLineJoin="round" />
+</vector>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -69,4 +69,6 @@
   <string name="clear_filters_button_content_description">Clear Filters Button</string>
   <string name="core_ui_scroll_to_top_button">Scroll to top</string>
   <string name="core_ui_toggle_password_visibility_button">Toggle password visibility</string>
+  <string name="core_ui_hidden_total_episodes_button">Total episodes are hidden</string>
+  <string name="core_ui_visible_total_episodes_button">Total episodes are visible</string>
 </resources>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -7,7 +7,10 @@
   <string name="core_ui_save">Save</string>
 
   <string name="core_ui_share">Share</string>
-  <string name="core_ui_dropdown_menu_request">Request</string>
+  <string name="core_ui_show_total_episodes_item">Show spoilers</string>
+  <string name="core_ui_hide_total_episodes_item">Hide spoilers</string>
+  <string name="core_ui_show_spoilers_tooltip">Show credits\' episode count</string>
+  <string name="core_ui_hide_spoilers_tooltip">Hide credits\' episode count to avoid spoilers</string>
 
   <string name="core_ui_retry">Retry</string>
   <string name="core_ui_login">Login</string>
@@ -69,6 +72,6 @@
   <string name="clear_filters_button_content_description">Clear Filters Button</string>
   <string name="core_ui_scroll_to_top_button">Scroll to top</string>
   <string name="core_ui_toggle_password_visibility_button">Toggle password visibility</string>
-  <string name="core_ui_hidden_total_episodes_button">Total episodes are hidden</string>
-  <string name="core_ui_visible_total_episodes_button">Total episodes are visible</string>
+  <string name="core_ui_hidden_spoilers_button">Spoilers are hidden</string>
+  <string name="core_ui_visible_spoilers_button">Spoilers are visible</string>
 </resources>

--- a/core/ui/src/screenshotTest/kotlin/com/divinelink/core/ui/ObfuscateSpoilersMenuItemScreenshots.kt
+++ b/core/ui/src/screenshotTest/kotlin/com/divinelink/core/ui/ObfuscateSpoilersMenuItemScreenshots.kt
@@ -1,0 +1,10 @@
+package com.divinelink.core.ui
+
+import androidx.compose.runtime.Composable
+import com.divinelink.core.ui.components.dropdownmenu.ObfuscateTotalEpisodesMenuItemPreview
+
+@Previews
+@Composable
+fun ObfuscateSpoilersMenuItemScreenshots() {
+  ObfuscateTotalEpisodesMenuItemPreview()
+}

--- a/core/ui/src/test/kotlin/com/divinelink/core/ui/DetailsDropDownMenuTest.kt
+++ b/core/ui/src/test/kotlin/com/divinelink/core/ui/DetailsDropDownMenuTest.kt
@@ -18,11 +18,57 @@ class DetailsDropDownMenuTest : ComposeTest() {
         expanded = true,
         options = listOf(DetailsMenuOptions.SHARE),
         onDismissDropdown = {},
+        spoilersObfuscated = false,
+        onObfuscateClick = {},
       )
     }
 
     composeTestRule.onNodeWithTag(
       TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_share)),
+    ).assertIsDisplayed()
+  }
+
+  @Test
+  fun `test show details drop down menu with share and spoiler option with obfuscated`() {
+    composeTestRule.setContent {
+      DetailsDropdownMenu(
+        mediaDetails = MediaDetailsFactory.FightClub(),
+        expanded = true,
+        options = listOf(DetailsMenuOptions.SHARE, DetailsMenuOptions.OBFUSCATE_SPOILERS),
+        onDismissDropdown = {},
+        spoilersObfuscated = true,
+        onObfuscateClick = {},
+      )
+    }
+
+    composeTestRule.onNodeWithTag(
+      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_share)),
+    ).assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag(
+      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_show_total_episodes_item)),
+    ).assertIsDisplayed()
+  }
+
+  @Test
+  fun `test show details drop down menu with share and spoiler option without obfuscated`() {
+    composeTestRule.setContent {
+      DetailsDropdownMenu(
+        mediaDetails = MediaDetailsFactory.FightClub(),
+        expanded = true,
+        options = listOf(DetailsMenuOptions.SHARE, DetailsMenuOptions.OBFUSCATE_SPOILERS),
+        onDismissDropdown = {},
+        spoilersObfuscated = false,
+        onObfuscateClick = {},
+      )
+    }
+
+    composeTestRule.onNodeWithTag(
+      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_share)),
+    ).assertIsDisplayed()
+
+    composeTestRule.onNodeWithTag(
+      TestTags.Menu.MENU_ITEM.format(getString(R.string.core_ui_hide_total_episodes_item)),
     ).assertIsDisplayed()
   }
 }

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/provider/CreditsUiStateParameterProvider.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/provider/CreditsUiStateParameterProvider.kt
@@ -44,7 +44,7 @@ class CreditsUiStateParameterProvider : PreviewParameterProvider<CreditsUiState>
           ),
         ),
       ),
-      episodesObfuscated = false,
+      obfuscateSpoilers = false,
     ),
     CreditsUiState(
       selectedTabIndex = 1,
@@ -79,7 +79,7 @@ class CreditsUiStateParameterProvider : PreviewParameterProvider<CreditsUiState>
           ),
         ),
       ),
-      episodesObfuscated = false,
+      obfuscateSpoilers = false,
     ),
     CreditsUiState(
       selectedTabIndex = 0,
@@ -95,7 +95,7 @@ class CreditsUiStateParameterProvider : PreviewParameterProvider<CreditsUiState>
           crew = listOf(),
         ),
       ),
-      episodesObfuscated = false,
+      obfuscateSpoilers = false,
     ),
     CreditsUiState(
       selectedTabIndex = 1,
@@ -111,7 +111,7 @@ class CreditsUiStateParameterProvider : PreviewParameterProvider<CreditsUiState>
           crew = listOf(),
         ),
       ),
-      episodesObfuscated = false,
+      obfuscateSpoilers = false,
     ),
     CreditsUiState(
       selectedTabIndex = 0,
@@ -146,7 +146,7 @@ class CreditsUiStateParameterProvider : PreviewParameterProvider<CreditsUiState>
           ),
         ),
       ),
-      episodesObfuscated = true,
+      obfuscateSpoilers = true,
     ),
   )
 }

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/provider/CreditsUiStateParameterProvider.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/provider/CreditsUiStateParameterProvider.kt
@@ -44,6 +44,7 @@ class CreditsUiStateParameterProvider : PreviewParameterProvider<CreditsUiState>
           ),
         ),
       ),
+      episodesObfuscated = false,
     ),
     CreditsUiState(
       selectedTabIndex = 1,
@@ -78,6 +79,7 @@ class CreditsUiStateParameterProvider : PreviewParameterProvider<CreditsUiState>
           ),
         ),
       ),
+      episodesObfuscated = false,
     ),
     CreditsUiState(
       selectedTabIndex = 0,
@@ -93,6 +95,7 @@ class CreditsUiStateParameterProvider : PreviewParameterProvider<CreditsUiState>
           crew = listOf(),
         ),
       ),
+      episodesObfuscated = false,
     ),
     CreditsUiState(
       selectedTabIndex = 1,
@@ -108,6 +111,42 @@ class CreditsUiStateParameterProvider : PreviewParameterProvider<CreditsUiState>
           crew = listOf(),
         ),
       ),
+      episodesObfuscated = false,
+    ),
+    CreditsUiState(
+      selectedTabIndex = 0,
+      tabs = listOf(
+        CreditsTab.Cast(2),
+        CreditsTab.Crew(4),
+      ),
+      forms = mapOf(
+        CreditsTab.Cast(2) to CreditsUiContent.Cast(
+          cast = listOf(
+            CreditsUiStateParameters.actor1,
+            CreditsUiStateParameters.actor2,
+            CreditsUiStateParameters.actor3,
+          ),
+        ),
+        CreditsTab.Crew(4) to CreditsUiContent.Crew(
+          crew = listOf(
+            SeriesCrewDepartment(
+              department = "Department 1",
+              crewList = listOf(
+                CreditsUiStateParameters.crew1,
+                CreditsUiStateParameters.crew2,
+                CreditsUiStateParameters.crew3,
+              ),
+            ),
+            SeriesCrewDepartment(
+              department = "Department 2",
+              crewList = listOf(
+                CreditsUiStateParameters.crew1,
+              ),
+            ),
+          ),
+        ),
+      ),
+      episodesObfuscated = true,
     ),
   )
 }

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsContent.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsContent.kt
@@ -89,7 +89,7 @@ fun CreditsContent(
                 PersonItem(
                   person = person,
                   onClick = onPersonSelected,
-                  isObfuscated = state.episodesObfuscated,
+                  isObfuscated = state.obfuscateSpoilers,
                 )
               }
             }
@@ -128,7 +128,7 @@ fun CreditsContent(
                   PersonItem(
                     person = person,
                     onClick = onPersonSelected,
-                    isObfuscated = state.episodesObfuscated,
+                    isObfuscated = state.obfuscateSpoilers,
                   )
                 }
               }

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsContent.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsContent.kt
@@ -89,6 +89,7 @@ fun CreditsContent(
                 PersonItem(
                   person = person,
                   onClick = onPersonSelected,
+                  isObfuscated = state.episodesObfuscated,
                 )
               }
             }
@@ -127,6 +128,7 @@ fun CreditsContent(
                   PersonItem(
                     person = person,
                     onClick = onPersonSelected,
+                    isObfuscated = state.episodesObfuscated,
                   )
                 }
               }

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsScreen.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsScreen.kt
@@ -55,7 +55,7 @@ fun CreditsScreen(
         actions = {
           ObfuscateSpoilersButton(
             obfuscated = uiState.obfuscateSpoilers,
-            onClick = viewModel::onObfuscateSpoilersClick,
+            onClick = viewModel::onObfuscateSpoilers,
           )
         },
         navigationIcon = {

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsScreen.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import com.divinelink.core.model.details.Person
 import com.divinelink.core.navigation.arguments.CreditsNavArguments
+import com.divinelink.core.ui.components.ObfuscateSpoilersButton
 import com.divinelink.core.ui.components.scaffold.AppScaffold
 import com.divinelink.feature.credits.R
 import com.divinelink.feature.credits.navigation.CreditsGraph
@@ -49,6 +50,12 @@ fun CreditsScreen(
             maxLines = 2,
             style = MaterialTheme.typography.titleLarge,
             overflow = TextOverflow.Ellipsis,
+          )
+        },
+        actions = {
+          ObfuscateSpoilersButton(
+            obfuscated = uiState.obfuscateSpoilers,
+            onClick = viewModel::onObfuscateSpoilersClick,
           )
         },
         navigationIcon = {

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsUiState.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsUiState.kt
@@ -4,6 +4,7 @@ data class CreditsUiState(
   val selectedTabIndex: Int,
   val tabs: List<CreditsTab>,
   val forms: Map<CreditsTab, CreditsUiContent>,
+  val episodesObfuscated: Boolean,
 ) {
   companion object {
     fun initial(): CreditsUiState = CreditsUiState(
@@ -16,6 +17,7 @@ data class CreditsUiState(
         CreditsTab.Cast(0) to CreditsUiContent.Cast(emptyList()),
         CreditsTab.Crew(0) to CreditsUiContent.Crew(emptyList()),
       ),
+      episodesObfuscated = false,
     )
   }
 }

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsUiState.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsUiState.kt
@@ -4,7 +4,7 @@ data class CreditsUiState(
   val selectedTabIndex: Int,
   val tabs: List<CreditsTab>,
   val forms: Map<CreditsTab, CreditsUiContent>,
-  val episodesObfuscated: Boolean,
+  val obfuscateSpoilers: Boolean,
 ) {
   companion object {
     fun initial(): CreditsUiState = CreditsUiState(
@@ -17,7 +17,7 @@ data class CreditsUiState(
         CreditsTab.Cast(0) to CreditsUiContent.Cast(emptyList()),
         CreditsTab.Crew(0) to CreditsUiContent.Crew(emptyList()),
       ),
-      episodesObfuscated = false,
+      obfuscateSpoilers = false,
     )
   }
 }

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsViewModel.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsViewModel.kt
@@ -71,7 +71,7 @@ class CreditsViewModel(
     }
   }
 
-  fun onObfuscateSpoilersClick() {
+  fun onObfuscateSpoilers() {
     viewModelScope.launch {
       spoilersObfuscationUseCase.setSpoilersObfuscation(
         !uiState.value.obfuscateSpoilers,

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsViewModel.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsViewModel.kt
@@ -3,7 +3,9 @@ package com.divinelink.feature.credits.ui
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.divinelink.core.commons.domain.data
 import com.divinelink.core.domain.credits.FetchCreditsUseCase
+import com.divinelink.core.domain.credits.SpoilersObfuscationUseCase
 import com.divinelink.core.navigation.arguments.CreditsNavArguments
 import com.divinelink.feature.credits.screens.destinations.CreditsScreenDestination
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -11,10 +13,12 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 
 class CreditsViewModel(
   fetchCreditsUseCase: FetchCreditsUseCase,
   savedStateHandle: SavedStateHandle,
+  private val spoilersObfuscationUseCase: SpoilersObfuscationUseCase,
 ) : ViewModel() {
 
   private val args: CreditsNavArguments = CreditsScreenDestination.argsFrom(savedStateHandle)
@@ -51,11 +55,27 @@ class CreditsViewModel(
         }
       }
       .launchIn(viewModelScope)
+
+    viewModelScope.launch {
+      spoilersObfuscationUseCase(Unit).collect { obfuscateSpoilers ->
+        _uiState.update {
+          it.copy(obfuscateSpoilers = obfuscateSpoilers.data)
+        }
+      }
+    }
   }
 
   fun onTabSelected(tabIndex: Int) {
     _uiState.update {
       it.copy(selectedTabIndex = tabIndex)
+    }
+  }
+
+  fun onObfuscateSpoilersClick() {
+    viewModelScope.launch {
+      spoilersObfuscationUseCase.setSpoilersObfuscation(
+        !uiState.value.obfuscateSpoilers,
+      )
     }
   }
 }

--- a/feature/credits/src/screenshotTest/kotlin/com/divinelink/feature/credits/PersonItemScreenshots.kt
+++ b/feature/credits/src/screenshotTest/kotlin/com/divinelink/feature/credits/PersonItemScreenshots.kt
@@ -1,0 +1,11 @@
+package com.divinelink.feature.credits
+
+import androidx.compose.runtime.Composable
+import com.divinelink.core.ui.Previews
+import com.divinelink.feature.credits.ui.PersonItemPreview
+
+@Previews
+@Composable
+fun PersonItemScreenshots() {
+  PersonItemPreview()
+}

--- a/feature/credits/src/test/kotlin/com/divinelink/feature/credits/ui/CreditsScreenTest.kt
+++ b/feature/credits/src/test/kotlin/com/divinelink/feature/credits/ui/CreditsScreenTest.kt
@@ -2,12 +2,15 @@ package com.divinelink.feature.credits.ui
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTouchInput
 import androidx.lifecycle.SavedStateHandle
+import com.divinelink.core.domain.credits.SpoilersObfuscationUseCase
 import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.testing.ComposeTest
 import com.divinelink.core.testing.factories.details.credits.AggregatedCreditsFactory
@@ -15,6 +18,7 @@ import com.divinelink.core.testing.getString
 import com.divinelink.core.testing.navigator.FakeDestinationsNavigator
 import com.divinelink.core.testing.setContentWithTheme
 import com.divinelink.core.testing.usecase.TestFetchCreditsUseCase
+import com.divinelink.core.testing.usecase.TestSpoilersObfuscationUseCase
 import com.divinelink.core.ui.TestTags
 import com.divinelink.feature.credits.R
 import kotlinx.coroutines.flow.flowOf
@@ -26,12 +30,14 @@ class CreditsScreenTest : ComposeTest() {
 
   private lateinit var navigator: FakeDestinationsNavigator
   private lateinit var fetchCreditsUseCase: TestFetchCreditsUseCase
+  private lateinit var spoilersObfuscationUseCase: SpoilersObfuscationUseCase
   private lateinit var savedStateHandle: SavedStateHandle
 
   @BeforeTest
   fun setUp() {
     navigator = FakeDestinationsNavigator()
     fetchCreditsUseCase = TestFetchCreditsUseCase()
+    spoilersObfuscationUseCase = TestSpoilersObfuscationUseCase().useCase(false)
     savedStateHandle = SavedStateHandle(
       mapOf(
         "id" to 2316L,
@@ -44,6 +50,7 @@ class CreditsScreenTest : ComposeTest() {
   fun `test topAppBar is visible`() {
     val viewModel = CreditsViewModel(
       fetchCreditsUseCase = fetchCreditsUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
       savedStateHandle = savedStateHandle,
     )
 
@@ -63,6 +70,7 @@ class CreditsScreenTest : ComposeTest() {
   fun `test back button is visible`() {
     val viewModel = CreditsViewModel(
       fetchCreditsUseCase = fetchCreditsUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
       savedStateHandle = savedStateHandle,
     )
 
@@ -87,6 +95,7 @@ class CreditsScreenTest : ComposeTest() {
     )
     val viewModel = CreditsViewModel(
       fetchCreditsUseCase = fetchCreditsUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
       savedStateHandle = savedStateHandle,
     )
 
@@ -120,6 +129,7 @@ class CreditsScreenTest : ComposeTest() {
     )
     val viewModel = CreditsViewModel(
       fetchCreditsUseCase = fetchCreditsUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
       savedStateHandle = savedStateHandle,
     )
 
@@ -157,6 +167,7 @@ class CreditsScreenTest : ComposeTest() {
     )
     val viewModel = CreditsViewModel(
       fetchCreditsUseCase = fetchCreditsUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
       savedStateHandle = savedStateHandle,
     )
 
@@ -182,6 +193,7 @@ class CreditsScreenTest : ComposeTest() {
     )
     val viewModel = CreditsViewModel(
       fetchCreditsUseCase = fetchCreditsUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
       savedStateHandle = savedStateHandle,
     )
 
@@ -199,6 +211,53 @@ class CreditsScreenTest : ComposeTest() {
 
       onNodeWithTag(TestTags.BLANK_SLATE).assertIsDisplayed()
       onNodeWithText(getString(R.string.feature_credits_crew_missing)).assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun `test obfuscate spoilers button`() {
+    fetchCreditsUseCase.mockSuccess(
+      flowOf(Result.success(AggregatedCreditsFactory.credits())),
+    )
+    val viewModel = CreditsViewModel(
+      fetchCreditsUseCase = fetchCreditsUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
+      savedStateHandle = savedStateHandle,
+    )
+
+    setContentWithTheme {
+      CreditsScreen(
+        navigator = navigator,
+        viewModel = viewModel,
+        onNavigateToPersonDetails = {},
+      )
+    }
+    with(composeTestRule) {
+      onNodeWithContentDescription(getString(uiR.string.core_ui_visible_spoilers_button))
+        .assertIsDisplayed()
+
+      onNodeWithTag(TestTags.Menu.SPOILERS_OBFUSCATION)
+        .assertIsDisplayed()
+        .performTouchInput {
+          longClick()
+        }
+
+      onNodeWithText(getString(uiR.string.core_ui_hide_spoilers_tooltip)).assertIsDisplayed()
+
+      onNodeWithTag(TestTags.Menu.SPOILERS_OBFUSCATION)
+        .assertIsDisplayed()
+        .performClick()
+
+      onNodeWithContentDescription(getString(uiR.string.core_ui_hidden_spoilers_button))
+        .assertIsDisplayed()
+
+      onNodeWithTag(TestTags.Menu.SPOILERS_OBFUSCATION)
+        .assertIsDisplayed()
+        .performTouchInput {
+          longClick()
+        }
+
+      onNodeWithText(getString(uiR.string.core_ui_show_spoilers_tooltip)).assertIsDisplayed()
     }
   }
 }

--- a/feature/credits/src/test/kotlin/com/divinelink/feature/credits/ui/CreditsViewModelTest.kt
+++ b/feature/credits/src/test/kotlin/com/divinelink/feature/credits/ui/CreditsViewModelTest.kt
@@ -2,11 +2,11 @@ package com.divinelink.feature.credits.ui
 
 import com.divinelink.core.model.credits.AggregateCredits
 import com.divinelink.core.model.media.MediaType
+import com.divinelink.core.navigation.arguments.CreditsNavArguments
 import com.divinelink.core.testing.MainDispatcherRule
 import com.divinelink.core.testing.assertUiState
 import com.divinelink.core.testing.expectUiStates
 import com.divinelink.core.testing.factories.details.credits.AggregatedCreditsFactory
-import com.divinelink.core.navigation.arguments.CreditsNavArguments
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -57,6 +57,7 @@ class CreditsViewModelTest {
             CreditsTab.Crew(12),
           ),
           selectedTabIndex = 0,
+          obfuscateSpoilers = false,
         ),
       )
   }
@@ -116,6 +117,7 @@ class CreditsViewModelTest {
               CreditsTab.Crew(12),
             ),
             selectedTabIndex = 0,
+            obfuscateSpoilers = false,
           ),
           CreditsUiState(
             forms = mapOf(
@@ -127,6 +129,7 @@ class CreditsViewModelTest {
               CreditsTab.Crew(12),
             ),
             selectedTabIndex = 0,
+            obfuscateSpoilers = false,
           ),
           CreditsUiState(
             forms = mapOf(
@@ -140,6 +143,7 @@ class CreditsViewModelTest {
               CreditsTab.Crew(12),
             ),
             selectedTabIndex = 0,
+            obfuscateSpoilers = false,
           ),
         ),
       )
@@ -169,6 +173,67 @@ class CreditsViewModelTest {
             CreditsTab.Crew(12),
           ),
           selectedTabIndex = 1,
+          obfuscateSpoilers = false,
+        ),
+      )
+  }
+
+  @Test
+  fun `test onObfuscateSpoilers with initial hidden`() = runTest {
+    robot
+      .withNavArgs(
+        CreditsNavArguments(
+          id = AggregatedCreditsFactory.credits().id,
+          mediaType = MediaType.TV,
+        ),
+      )
+      .mockFetchCreditsUseCaseSuccess(flowOf(Result.success(AggregatedCreditsFactory.credits())))
+      .buildViewModel()
+      .assertUiState(
+        CreditsUiState(
+          forms = mapOf(
+            CreditsTab.Cast(8) to CreditsUiContent.Cast(AggregatedCreditsFactory.credits().cast),
+            CreditsTab.Crew(12) to
+              CreditsUiContent.Crew(AggregatedCreditsFactory.credits().crewDepartments),
+          ),
+          tabs = listOf(
+            CreditsTab.Cast(8),
+            CreditsTab.Crew(12),
+          ),
+          selectedTabIndex = 0,
+          obfuscateSpoilers = false,
+        ),
+      )
+      .onObfuscateSpoilers()
+      .assertUiState(
+        CreditsUiState(
+          forms = mapOf(
+            CreditsTab.Cast(8) to CreditsUiContent.Cast(AggregatedCreditsFactory.credits().cast),
+            CreditsTab.Crew(12) to
+              CreditsUiContent.Crew(AggregatedCreditsFactory.credits().crewDepartments),
+          ),
+          tabs = listOf(
+            CreditsTab.Cast(8),
+            CreditsTab.Crew(12),
+          ),
+          selectedTabIndex = 0,
+          obfuscateSpoilers = true,
+        ),
+      )
+      .onObfuscateSpoilers()
+      .assertUiState(
+        CreditsUiState(
+          forms = mapOf(
+            CreditsTab.Cast(8) to CreditsUiContent.Cast(AggregatedCreditsFactory.credits().cast),
+            CreditsTab.Crew(12) to
+              CreditsUiContent.Crew(AggregatedCreditsFactory.credits().crewDepartments),
+          ),
+          tabs = listOf(
+            CreditsTab.Cast(8),
+            CreditsTab.Crew(12),
+          ),
+          selectedTabIndex = 0,
+          obfuscateSpoilers = false,
         ),
       )
   }

--- a/feature/credits/src/test/kotlin/com/divinelink/feature/credits/ui/CreditsViewModelTestRobot.kt
+++ b/feature/credits/src/test/kotlin/com/divinelink/feature/credits/ui/CreditsViewModelTestRobot.kt
@@ -2,15 +2,22 @@ package com.divinelink.feature.credits.ui
 
 import androidx.lifecycle.SavedStateHandle
 import com.divinelink.core.model.credits.AggregateCredits
+import com.divinelink.core.navigation.arguments.CreditsNavArguments
+import com.divinelink.core.testing.MainDispatcherRule
 import com.divinelink.core.testing.ViewModelTestRobot
 import com.divinelink.core.testing.usecase.TestFetchCreditsUseCase
-import com.divinelink.core.navigation.arguments.CreditsNavArguments
+import com.divinelink.core.testing.usecase.TestSpoilersObfuscationUseCase
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import org.junit.Rule
 
 class CreditsViewModelTestRobot : ViewModelTestRobot<CreditsUiState>() {
 
+  @get:Rule
+  val mainDispatcherRule = MainDispatcherRule()
+
   private val fetchCreditsUseCase = TestFetchCreditsUseCase()
+  private val spoilersObfuscationUseCase = TestSpoilersObfuscationUseCase().useCase()
 
   private lateinit var viewModel: CreditsViewModel
   private lateinit var navArgs: CreditsNavArguments
@@ -21,6 +28,7 @@ class CreditsViewModelTestRobot : ViewModelTestRobot<CreditsUiState>() {
   override fun buildViewModel() = apply {
     viewModel = CreditsViewModel(
       fetchCreditsUseCase = fetchCreditsUseCase.mock,
+      spoilersObfuscationUseCase = spoilersObfuscationUseCase,
       savedStateHandle = SavedStateHandle(
         mapOf(
           "id" to navArgs.id,
@@ -44,5 +52,9 @@ class CreditsViewModelTestRobot : ViewModelTestRobot<CreditsUiState>() {
 
   fun onTabSelected(tabIndex: Int) = apply {
     viewModel.onTabSelected(tabIndex)
+  }
+
+  fun onObfuscateSpoilers() = apply {
+    viewModel.onObfuscateSpoilers()
   }
 }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
@@ -76,7 +76,6 @@ import com.divinelink.core.ui.RatingSize
 import com.divinelink.core.ui.TestTags
 import com.divinelink.core.ui.UIText
 import com.divinelink.core.ui.components.LoadingContent
-import com.divinelink.core.ui.components.ObfuscateTotalEpisodesButton
 import com.divinelink.core.ui.components.WatchlistButton
 import com.divinelink.core.ui.components.details.SpannableRating
 import com.divinelink.core.ui.components.details.cast.CastList
@@ -112,6 +111,7 @@ fun DetailsContent(
   onAddToWatchlistClicked: () -> Unit,
   requestMedia: (List<Int>) -> Unit,
   viewAllCreditsClicked: () -> Unit,
+  onObfuscateSpoilers: () -> Unit,
 ) {
   val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
   var showDropdownMenu by remember { mutableStateOf(false) }
@@ -184,12 +184,6 @@ fun DetailsContent(
           }
         },
         actions = {
-          if (viewState.mediaDetails is TV) {
-            ObfuscateTotalEpisodesButton(
-              episodesObfuscated = viewState.seriesCreditsEpisodesObfuscated,
-              onClick = {},
-            )
-          }
           FavoriteButton(
             modifier = Modifier.clip(MaterialTheme.shape.roundedShape),
             isFavorite = viewState.mediaDetails?.isFavorite ?: false,
@@ -209,7 +203,9 @@ fun DetailsContent(
               mediaDetails = viewState.mediaDetails,
               expanded = showDropdownMenu,
               options = viewState.menuOptions,
+              spoilersObfuscated = viewState.spoilersObfuscated,
               onDismissDropdown = { showDropdownMenu = false },
+              onObfuscateClick = onObfuscateSpoilers,
             )
           }
         },
@@ -232,6 +228,7 @@ fun DetailsContent(
               onAddToWatchlistClicked = onAddToWatchlistClicked,
               viewAllCreditsClicked = viewAllCreditsClicked,
               onPersonClick = onPersonClick,
+              obfuscateEpisodes = viewState.spoilersObfuscated,
             )
           }
         }
@@ -296,6 +293,7 @@ fun MediaDetailsContent(
   similarMoviesList: List<MediaItem.Media>?,
   reviewsList: List<Review>?,
   trailer: Video?,
+  obfuscateEpisodes: Boolean,
   onPersonClick: (Person) -> Unit,
   onSimilarMovieClicked: (MediaItem.Media) -> Unit,
   onAddRateClicked: () -> Unit,
@@ -304,130 +302,129 @@ fun MediaDetailsContent(
 ) {
   val showStickyPlayer = remember { mutableStateOf(false) }
 
-  Surface {
-    LazyColumn(
-      modifier = modifier
-        .testTag(TestTags.Details.CONTENT_LIST)
-        .fillMaxWidth(),
-    ) {
-      item {
-        TitleDetails(mediaDetails)
-      }
-      if (trailer != null) {
-        stickyHeader(key = "trailerSticky") {
-          Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-              .fillMaxWidth()
-              .background(Color.Black),
-          ) {
-            VideoPlayerSection(
-              modifier = Modifier,
-              trailer = trailer,
-              onVideoStateChange = { state ->
-                showStickyPlayer.value = state == VideoState.PLAYING
-              },
-            )
-          }
-        }
-
-        if (!showStickyPlayer.value) {
-          stickyHeader {
-            Spacer(modifier = Modifier.height(MaterialTheme.dimensions.keyline_0))
-          }
-        }
-      }
-
-      item {
-        Row(
+  LazyColumn(
+    modifier = modifier
+      .testTag(TestTags.Details.CONTENT_LIST)
+      .fillMaxWidth(),
+  ) {
+    item {
+      TitleDetails(mediaDetails)
+    }
+    if (trailer != null) {
+      stickyHeader(key = "trailerSticky") {
+        Box(
+          contentAlignment = Alignment.Center,
           modifier = Modifier
             .fillMaxWidth()
-            .padding(paddingValues = ListPaddingValues),
+            .background(Color.Black),
         ) {
-          MovieImage(
-            modifier = Modifier.weight(1f),
-            path = mediaDetails.posterPath,
-          )
-
-          OverviewDetails(
-            modifier = Modifier.weight(OVERVIEW_WEIGHT),
-            movieDetails = mediaDetails,
-            genres = mediaDetails.genres,
-            onGenreClicked = {},
+          VideoPlayerSection(
+            modifier = Modifier,
+            trailer = trailer,
+            onVideoStateChange = { state ->
+              showStickyPlayer.value = state == VideoState.PLAYING
+            },
           )
         }
       }
 
-      item {
-        WatchlistButton(
-          modifier = Modifier.padding(paddingValues = ListPaddingValues),
-          onWatchlist = userDetails?.watchlist == true,
-          onClick = onAddToWatchlistClicked,
+      if (!showStickyPlayer.value) {
+        stickyHeader {
+          Spacer(modifier = Modifier.height(MaterialTheme.dimensions.keyline_0))
+        }
+      }
+    }
+
+    item {
+      Row(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(paddingValues = ListPaddingValues),
+      ) {
+        MovieImage(
+          modifier = Modifier.weight(1f),
+          path = mediaDetails.posterPath,
+        )
+
+        OverviewDetails(
+          modifier = Modifier.weight(OVERVIEW_WEIGHT),
+          movieDetails = mediaDetails,
+          genres = mediaDetails.genres,
+          onGenreClicked = {},
         )
       }
+    }
 
+    item {
+      WatchlistButton(
+        modifier = Modifier.padding(paddingValues = ListPaddingValues),
+        onWatchlist = userDetails?.watchlist == true,
+        onClick = onAddToWatchlistClicked,
+      )
+    }
+
+    item {
+      UserRating(
+        overallUserScore = mediaDetails.rating,
+        userRating = userDetails?.beautifiedRating,
+        onAddRateClicked = onAddRateClicked,
+      )
+    }
+
+    item {
+      if (mediaDetails is TV && tvCredits != null) {
+        HorizontalDivider(
+          modifier = Modifier.padding(top = MaterialTheme.dimensions.keyline_16),
+          thickness = MaterialTheme.dimensions.keyline_1,
+        )
+        CastList(
+          cast = tvCredits.take(30),
+          onViewAllClick = viewAllCreditsClicked,
+          onPersonClick = onPersonClick,
+          obfuscateEpisodes = obfuscateEpisodes,
+        ) // This is temporary
+        CreatorsItem(
+          creators = mediaDetails.creators,
+          onClick = onPersonClick,
+        )
+      } else if (mediaDetails is Movie) {
+        HorizontalDivider(
+          modifier = Modifier.padding(top = MaterialTheme.dimensions.keyline_16),
+          thickness = MaterialTheme.dimensions.keyline_1,
+        )
+        CastList(
+          cast = mediaDetails.cast,
+          onViewAllClick = viewAllCreditsClicked,
+          viewAllVisible = false,
+          onPersonClick = onPersonClick,
+        )
+        mediaDetails.director?.let {
+          DirectorItem(director = it, onClick = onPersonClick)
+        }
+      }
+      Spacer(modifier = Modifier.height(MaterialTheme.dimensions.keyline_4))
+    }
+    if (similarMoviesList?.isNotEmpty() == true) {
       item {
-        UserRating(
-          overallUserScore = mediaDetails.rating,
-          userRating = userDetails?.beautifiedRating,
-          onAddRateClicked = onAddRateClicked,
+        HorizontalDivider(thickness = MaterialTheme.dimensions.keyline_1)
+        SimilarMoviesList(
+          movies = similarMoviesList,
+          onSimilarMovieClicked = onSimilarMovieClicked,
         )
       }
+    }
 
+    if (!reviewsList.isNullOrEmpty()) {
       item {
-        if (mediaDetails is TV && tvCredits != null) {
-          HorizontalDivider(
-            modifier = Modifier.padding(top = MaterialTheme.dimensions.keyline_16),
-            thickness = MaterialTheme.dimensions.keyline_1,
-          )
-          CastList(
-            cast = tvCredits.take(30),
-            onViewAllClick = viewAllCreditsClicked,
-            onPersonClick = onPersonClick,
-          ) // This is temporary
-          CreatorsItem(
-            creators = mediaDetails.creators,
-            onClick = onPersonClick,
-          )
-        } else if (mediaDetails is Movie) {
-          HorizontalDivider(
-            modifier = Modifier.padding(top = MaterialTheme.dimensions.keyline_16),
-            thickness = MaterialTheme.dimensions.keyline_1,
-          )
-          CastList(
-            cast = mediaDetails.cast,
-            onViewAllClick = viewAllCreditsClicked,
-            viewAllVisible = false,
-            onPersonClick = onPersonClick,
-          )
-          mediaDetails.director?.let {
-            DirectorItem(director = it, onClick = onPersonClick)
-          }
-        }
-        Spacer(modifier = Modifier.height(MaterialTheme.dimensions.keyline_4))
+        HorizontalDivider(thickness = MaterialTheme.dimensions.keyline_1)
+        ReviewsList(
+          reviews = reviewsList,
+        )
       }
-      if (similarMoviesList?.isNotEmpty() == true) {
-        item {
-          HorizontalDivider(thickness = MaterialTheme.dimensions.keyline_1)
-          SimilarMoviesList(
-            movies = similarMoviesList,
-            onSimilarMovieClicked = onSimilarMovieClicked,
-          )
-        }
-      }
+    }
 
-      if (!reviewsList.isNullOrEmpty()) {
-        item {
-          HorizontalDivider(thickness = MaterialTheme.dimensions.keyline_1)
-          ReviewsList(
-            reviews = reviewsList,
-          )
-        }
-      }
-
-      item {
-        Spacer(modifier = Modifier.height(MaterialTheme.dimensions.keyline_16))
-      }
+    item {
+      Spacer(modifier = Modifier.height(MaterialTheme.dimensions.keyline_16))
     }
   }
 }
@@ -603,6 +600,7 @@ private fun DetailsContentPreview(
           requestMedia = {},
           onPersonClick = {},
           viewAllCreditsClicked = {},
+          onObfuscateSpoilers = {},
         )
       }
     }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
@@ -76,6 +76,7 @@ import com.divinelink.core.ui.RatingSize
 import com.divinelink.core.ui.TestTags
 import com.divinelink.core.ui.UIText
 import com.divinelink.core.ui.components.LoadingContent
+import com.divinelink.core.ui.components.ObfuscateTotalEpisodesButton
 import com.divinelink.core.ui.components.WatchlistButton
 import com.divinelink.core.ui.components.details.SpannableRating
 import com.divinelink.core.ui.components.details.cast.CastList
@@ -183,6 +184,12 @@ fun DetailsContent(
           }
         },
         actions = {
+          if (viewState.mediaDetails is TV) {
+            ObfuscateTotalEpisodesButton(
+              episodesObfuscated = viewState.seriesCreditsEpisodesObfuscated,
+              onClick = {},
+            )
+          }
           FavoriteButton(
             modifier = Modifier.clip(MaterialTheme.shape.roundedShape),
             isFavorite = viewState.mediaDetails?.isFavorite ?: false,

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
@@ -103,6 +103,7 @@ fun DetailsScreen(
     onAddRateClicked = viewModel::onAddRateClicked,
     onAddToWatchlistClicked = viewModel::onAddToWatchlist,
     requestMedia = viewModel::onRequestMedia,
+    onObfuscateSpoilers = viewModel::onObfuscateSpoilers,
     viewAllCreditsClicked = {
       onNavigateToCredits(
         CreditsNavArguments(

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -11,6 +11,7 @@ import com.divinelink.core.data.details.model.MediaDetailsException
 import com.divinelink.core.data.jellyseerr.model.JellyseerrRequestParams
 import com.divinelink.core.data.session.model.SessionException
 import com.divinelink.core.domain.MarkAsFavoriteUseCase
+import com.divinelink.core.domain.credits.SpoilersObfuscationUseCase
 import com.divinelink.core.domain.jellyseerr.RequestMediaUseCase
 import com.divinelink.core.model.account.AccountMediaDetails
 import com.divinelink.core.model.media.MediaType
@@ -47,6 +48,7 @@ class DetailsViewModel(
   private val deleteRatingUseCase: DeleteRatingUseCase,
   private val addToWatchlistUseCase: AddToWatchlistUseCase,
   private val requestMediaUseCase: RequestMediaUseCase,
+  private val spoilersObfuscationUseCase: SpoilersObfuscationUseCase,
   savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
 
@@ -164,6 +166,14 @@ class DetailsViewModel(
           }
         }
       }.launchIn(viewModelScope)
+
+    viewModelScope.launch {
+      spoilersObfuscationUseCase.invoke(Unit).collect { obfuscatedSpoilers ->
+        _viewState.update { viewState ->
+          viewState.copy(spoilersObfuscated = obfuscatedSpoilers.data)
+        }
+      }
+    }
   }
 
   fun onSubmitRate(rating: Int) {
@@ -385,6 +395,14 @@ class DetailsViewModel(
         }
       }
       .launchIn(viewModelScope)
+  }
+
+  fun onObfuscateSpoilers() {
+    viewModelScope.launch {
+      spoilersObfuscationUseCase.setSpoilersObfuscation(
+        !viewState.value.spoilersObfuscated,
+      )
+    }
   }
 
   fun navigateToLogin(snackbarResult: SnackbarResult) {

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
@@ -30,6 +30,7 @@ data class DetailsViewState(
   val navigateToLogin: Boolean? = null,
   val menuOptions: List<DetailsMenuOptions> = emptyList(),
   val actionButtons: List<DetailActionItem> = emptyList(),
+  val seriesCreditsEpisodesObfuscated: Boolean = false,
 ) {
   val mediaItem = when (mediaDetails) {
     is Movie -> MediaItem.Media.Movie(

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
@@ -30,7 +30,7 @@ data class DetailsViewState(
   val navigateToLogin: Boolean? = null,
   val menuOptions: List<DetailsMenuOptions> = emptyList(),
   val actionButtons: List<DetailActionItem> = emptyList(),
-  val seriesCreditsEpisodesObfuscated: Boolean = false,
+  val spoilersObfuscated: Boolean = false,
 ) {
   val mediaItem = when (mediaDetails) {
     is Movie -> MediaItem.Media.Movie(

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/usecase/GetMediaDetailsUseCase.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/usecase/GetMediaDetailsUseCase.kt
@@ -131,7 +131,7 @@ open class GetMediaDetailsUseCase(
       }
 
       launch(dispatcher.io) {
-        getMenuItemsUseCase(Unit)
+        getMenuItemsUseCase(MediaType.from(requestApi.endpoint))
           .catch { Timber.e(it) }
           .collect { result ->
             result.onSuccess {

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/components/SettingsScaffold.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/components/SettingsScaffold.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarDefaults.topAppBarColors
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
@@ -61,7 +62,9 @@ fun SettingsScaffold(
           }
         },
         scrollBehavior = scrollBehavior,
-        colors = topAppBarColors(),
+        colors = topAppBarColors(
+          containerColor = Color.Transparent,
+        ),
       )
     },
     content = content,


### PR DESCRIPTION
This pull request introduces obfuscation on series crew total episodes. 

_I always felt that watching the number of total episodes for some character, is a kind of a spoiler. Therefore we added the option to obfuscate the number of episodes by blurring them._

- On the `Details Screen`, we've added a new dropdown menu option that allows the user to Show/Hide _potential spoilers_. This option blurs the total episodes for every TV series crew member. 
- On the `Credits Screen` there's an TopBar action button that has the same functionality. 

### Screen recoding & Screenshots 
 https://github.com/user-attachments/assets/e2784994-fc16-4193-ab71-e6a8c8094462

<img width="330" alt="Screenshot 2024-11-17 at 12 32 07 PM" src="https://github.com/user-attachments/assets/83fb9a8a-69cb-4146-bf76-c4349cb9f796">
<img width="330" alt="Screenshot 2024-11-17 at 12 32 16 PM" src="https://github.com/user-attachments/assets/2f147f4c-db89-4beb-a2c7-86f891346331">
