### PR TITLE
[Jellyseerr] Fix Jellyseerr Auth after API modifications

### DIFF
--- a/core/data/src/main/kotlin/com/divinelink/core/data/jellyseerr/repository/ProdJellyseerrRepository.kt
+++ b/core/data/src/main/kotlin/com/divinelink/core/data/jellyseerr/repository/ProdJellyseerrRepository.kt
@@ -36,7 +36,7 @@ class ProdJellyseerrRepository(
     address: String,
   ): Flow<Result<JellyseerrAccountDetails>> = service
     .fetchAccountDetails(address)
-    .map { Result.success(it.map()) }
+    .map { Result.success(it.map(address)) }
 
   override fun getLocalJellyseerrAccountDetails(): Flow<JellyseerrAccountDetails?> = queries
     .selectAll()

--- a/core/data/src/test/kotlin/com/divinelink/core/data/jellyseerr/ProdJellyseerrRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/divinelink/core/data/jellyseerr/ProdJellyseerrRepositoryTest.kt
@@ -136,13 +136,13 @@ class ProdJellyseerrRepositoryTest {
         id = domain.id,
         email = domain.email!!,
         displayName = domain.displayName,
-        avatar = domain.avatar,
+        avatar = "/avatarproxy/1dde62cf4a2c436d95e17b9",
         requestCount = domain.requestCount,
         createdAt = domain.createdAt,
       ),
     )
 
-    val result = repository.getRemoteAccountDetails("http://localhost:8096")
+    val result = repository.getRemoteAccountDetails("http://localhost:5000")
 
     assertThat(result.first()).isEqualTo(Result.success(JellyseerrAccountDetailsFactory.jellyfin()))
   }

--- a/core/network/src/main/kotlin/com/divinelink/core/network/client/PersistentCookieStorage.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/client/PersistentCookieStorage.kt
@@ -60,7 +60,6 @@ class PersistentCookieStorage(val storage: EncryptedStorage) : CookiesStorage {
       domain = parts[2],
       path = parts[3],
       expires = expires,
-      maxAge = parts[5].toInt(),
       secure = parts[6].toBoolean(),
       httpOnly = parts[7].toBoolean(),
     )

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/mapper/JellyseerrAccountDetailsResponseApiMapper.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/mapper/JellyseerrAccountDetailsResponseApiMapper.kt
@@ -4,10 +4,10 @@ import com.divinelink.core.commons.extensions.isValidEmail
 import com.divinelink.core.model.jellyseerr.JellyseerrAccountDetails
 import com.divinelink.core.network.jellyseerr.model.JellyseerrAccountDetailsResponseApi
 
-fun JellyseerrAccountDetailsResponseApi.map() = JellyseerrAccountDetails(
+fun JellyseerrAccountDetailsResponseApi.map(address: String) = JellyseerrAccountDetails(
   id = id,
   displayName = displayName,
-  avatar = avatar,
+  avatar = avatar?.let { address + it },
   requestCount = requestCount,
   email = if (email.isValidEmail()) email else null,
   createdAt = createdAt,

--- a/core/network/src/test/kotlin/com/divinelink/core/network/jellyseerr/JellyseerrAccountDetailsResponseApiMapperTest.kt
+++ b/core/network/src/test/kotlin/com/divinelink/core/network/jellyseerr/JellyseerrAccountDetailsResponseApiMapperTest.kt
@@ -11,7 +11,7 @@ class JellyseerrAccountDetailsResponseApiMapperTest {
   private val api = JellyseerrAccountDetailsResponseApi(
     id = 1,
     displayName = "Cup10",
-    avatar = "http://localhost:5000/avatar",
+    avatar = "/avatarproxy/1dde62cf4a2c436d95e17b9",
     requestCount = 10,
     email = "cup10@proton.me",
     createdAt = "2023-08-19T00:00:00.000Z",
@@ -19,14 +19,14 @@ class JellyseerrAccountDetailsResponseApiMapperTest {
 
   @Test
   fun `test JellyseerrAccountDetailsResponseApiMapper with valid email`() {
-    val result = api.map()
+    val result = api.map("http://localhost:5000")
 
     assertThat(result).isEqualTo(JellyseerrAccountDetailsFactory.jellyfin())
   }
 
   @Test
   fun `test JellyseerrAccountDetailsResponseApiMapper with invalid email`() {
-    val result = api.copy(email = "test.test@me").map()
+    val result = api.copy(email = "test.test@me").map("http://localhost:5000")
 
     assertThat(result).isEqualTo(JellyseerrAccountDetailsFactory.jellyfin().copy(email = null))
   }

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/entity/JellyseerrAccountDetailsEntityFactory.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/entity/JellyseerrAccountDetailsEntityFactory.kt
@@ -8,7 +8,7 @@ object JellyseerrAccountDetailsEntityFactory {
     id = 1,
     displayName = "Cup10",
     requestCount = 10,
-    avatar = "http://localhost:5000/avatar",
+    avatar = "http://localhost:5000/avatarproxy/1dde62cf4a2c436d95e17b9",
     email = "cup10@proton.me",
     createdAt = "2023-08-19T00:00:00.000Z",
   )

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/model/jellyseerr/JellyseerrAccountDetailsFactory.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/model/jellyseerr/JellyseerrAccountDetailsFactory.kt
@@ -7,7 +7,7 @@ object JellyseerrAccountDetailsFactory {
   fun jellyfin() = JellyseerrAccountDetails(
     id = 1,
     displayName = "Cup10",
-    avatar = "http://localhost:5000/avatar",
+    avatar = "http://localhost:5000/avatarproxy/1dde62cf4a2c436d95e17b9",
     requestCount = 10,
     email = "cup10@proton.me",
     createdAt = "2023-08-19T00:00:00.000Z",


### PR DESCRIPTION
This pull request fixes authentication with Jellyseerr after breaking changes in the API. 

Changes involve: 
- Remove `maxAge` from cookie since it now returns null
- Fix account avatar url

Initially, the `auth/me` response would include the server address on the avatar url, but now it does not and we have to add that ourselves. 

