### PR TITLE
[External Media] Open custom tab to external media (IMDb, Trakt, TMDB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The following table outlines the main features of our app:
 | Cast & Crew Information   | Explore the team behind movies and TV shows   | ✅ Implemented       |
 | Jellyseerr Authentication | Log in to your Jellyseerr account             | ✅ Implemented       |
 | Jellyseerr Requests       | Request movies and TV shows via Jellyseerr    | ✅ Implemented       |
+| Additional Rating Sources | View IMDb & Trakt ratings for all content     | ✅ Implemented       |
 | Discover Feed             | Personalized content recommendations          | 🚧 Work in Progress |
 | TV Show Seasons           | Detailed information about individual seasons | 🚧 Work in Progress |
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,13 +29,11 @@
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />
 
-        <data
-            android:host="www.themoviedb.org"
-            android:scheme="https" />
-
-        <data android:pathPattern="/tv/.*" />
+        <data android:scheme="https" />
+        <data android:host="www.themoviedb.org" />
         <data android:pathPattern="/movie/.*" />
         <data android:pathPattern="/person/.*" />
+        <data android:pathPattern="/tv/.*" />
       </intent-filter>
     </activity>
 
@@ -49,4 +47,11 @@
           android:value="androidx.startup" />
     </provider>
   </application>
+
+  <queries>
+    <intent>
+      <action android:name="android.support.customtabs.action.CustomTabsService" />
+    </intent>
+  </queries>
+
 </manifest>

--- a/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelRobot.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelRobot.kt
@@ -2,6 +2,8 @@ package com.divinelink.scenepeek.details.ui
 
 import androidx.compose.material3.SnackbarResult
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.TurbineTestContext
+import app.cash.turbine.test
 import com.divinelink.core.domain.credits.SpoilersObfuscationUseCase
 import com.divinelink.core.model.details.rating.RatingDetails
 import com.divinelink.core.model.details.rating.RatingSource
@@ -25,6 +27,7 @@ import com.divinelink.scenepeek.fakes.usecase.details.FakeSubmitRatingUseCase
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 
 class DetailsViewModelRobot : ViewModelTestRobot<DetailsViewState>() {
@@ -74,6 +77,14 @@ class DetailsViewModelRobot : ViewModelTestRobot<DetailsViewState>() {
 
   fun assertViewState(expectedViewState: DetailsViewState) = apply {
     assertThat(viewModel.viewState.value).isEqualTo(expectedViewState)
+  }
+
+  fun assertOpenUrlTab(validate: suspend TurbineTestContext<String>.() -> Unit) = apply {
+    runTest {
+      viewModel.openUrlTab.test {
+        validate()
+      }
+    }
   }
 
   fun mockFetchMediaDetails(response: Flow<Result<MediaDetailsResult>>) = apply {
@@ -174,6 +185,10 @@ class DetailsViewModelRobot : ViewModelTestRobot<DetailsViewState>() {
     fakeAddToWatchListUseCase.mockAddToWatchlist(
       response = response,
     )
+  }
+
+  fun onMediaSourceClick(source: RatingSource) = apply {
+    viewModel.onMediaSourceClick(source)
   }
 
   suspend fun mockSpoilersObfuscation(obfuscated: Boolean) = apply {

--- a/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelRobot.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelRobot.kt
@@ -118,8 +118,8 @@ class DetailsViewModelRobot : ViewModelTestRobot<DetailsViewState>() {
     viewModel.onRequestMedia(seasons)
   }
 
-  fun onFetchAllRating() = apply {
-    viewModel.onFetchAllRating()
+  fun onFetchAllRatings() = apply {
+    viewModel.onFetchAllRatings()
   }
 
   fun onObfuscateSpoilers() = apply {

--- a/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelTest.kt
@@ -29,6 +29,7 @@ import com.divinelink.feature.details.R
 import com.divinelink.feature.details.media.ui.DetailsViewModel
 import com.divinelink.feature.details.media.ui.DetailsViewState
 import com.divinelink.feature.details.media.ui.MediaDetailsResult
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -1454,5 +1455,113 @@ class DetailsViewModelTest {
           ),
         ),
       )
+  }
+
+  @Test
+  fun `test onMediaSourceClick for TV show emits openUrl`() = runTest {
+    testRobot
+      .mockFetchMediaDetails(
+        response = defaultDetails(MediaDetailsResult.DetailsSuccess(tvDetails, RatingSource.TMDB)),
+      )
+      .withNavArguments(2316, MediaType.TV)
+      .buildViewModel()
+      .onMediaSourceClick(RatingSource.TMDB)
+      .assertViewState(
+        DetailsViewState(
+          mediaType = MediaType.TV,
+          mediaId = 2316,
+          isLoading = false,
+          userDetails = AccountMediaDetailsFactory.NotRated(),
+          mediaDetails = tvDetails,
+          spoilersObfuscated = false,
+        ),
+      )
+      .assertOpenUrlTab {
+        assertThat(awaitItem()).isEqualTo(
+          "https://www.themoviedb.org/tv/2316-the-office",
+        )
+      }
+      .onMediaSourceClick(RatingSource.IMDB)
+      .assertOpenUrlTab {
+        assertThat(awaitItem()).isEqualTo("https://www.imdb.com/title/tt0386676")
+      }
+      .onMediaSourceClick(RatingSource.TRAKT)
+      .assertOpenUrlTab {
+        assertThat(awaitItem()).isEqualTo("https://trakt.tv/shows/tt0386676")
+      }
+  }
+
+  @Test
+  fun `test onMediaSourceClick for movie emits openUrl`() = runTest {
+    testRobot
+      .mockFetchMediaDetails(
+        response = defaultDetails(
+          MediaDetailsResult.DetailsSuccess(
+            mediaDetails = movieDetails,
+            ratingSource = RatingSource.TMDB,
+          ),
+        ),
+      )
+      .withNavArguments(movieDetails.id, MediaType.MOVIE)
+      .buildViewModel()
+      .onMediaSourceClick(RatingSource.TMDB)
+      .assertViewState(
+        DetailsViewState(
+          mediaType = MediaType.MOVIE,
+          mediaId = movieDetails.id,
+          isLoading = false,
+          userDetails = AccountMediaDetailsFactory.NotRated(),
+          mediaDetails = movieDetails,
+          spoilersObfuscated = false,
+        ),
+      )
+      .assertOpenUrlTab {
+        assertThat(awaitItem()).isEqualTo(
+          "https://www.themoviedb.org/movie/1123-flight-club",
+        )
+      }
+      .onMediaSourceClick(RatingSource.IMDB)
+      .assertOpenUrlTab {
+        assertThat(awaitItem()).isEqualTo("https://www.imdb.com/title/tt0137523")
+      }
+      .onMediaSourceClick(RatingSource.TRAKT)
+      .assertOpenUrlTab {
+        assertThat(awaitItem()).isEqualTo("https://trakt.tv/movies/tt0137523")
+      }
+  }
+
+  @Test
+  fun `test onMediaSourceClick for movie emits openUrls`() = runTest {
+    testRobot
+      .mockFetchMediaDetails(
+        response = defaultDetails(
+          MediaDetailsResult.DetailsSuccess(
+            mediaDetails = movieDetails.copy(imdbId = null),
+            ratingSource = RatingSource.TMDB,
+          ),
+        ),
+      )
+      .withNavArguments(movieDetails.id, MediaType.MOVIE)
+      .buildViewModel()
+      .onMediaSourceClick(RatingSource.TMDB)
+      .assertViewState(
+        DetailsViewState(
+          mediaType = MediaType.MOVIE,
+          mediaId = movieDetails.id,
+          isLoading = false,
+          userDetails = AccountMediaDetailsFactory.NotRated(),
+          mediaDetails = movieDetails.copy(imdbId = null),
+          spoilersObfuscated = false,
+        ),
+      )
+      .assertOpenUrlTab {
+        assertThat(awaitItem()).isEqualTo(
+          "https://www.themoviedb.org/movie/1123-flight-club",
+        )
+      }
+      .onMediaSourceClick(RatingSource.IMDB)
+      .assertOpenUrlTab { expectNoEvents() }
+      .onMediaSourceClick(RatingSource.TRAKT)
+      .assertOpenUrlTab { expectNoEvents() }
   }
 }

--- a/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelTest.kt
@@ -1380,7 +1380,7 @@ class DetailsViewModelTest {
       .mockFetchAllRatingsUseCase(allRatingsChannel)
       .expectUiStates(
         action = {
-          onFetchAllRating()
+          onFetchAllRatings()
 
           launch {
             allRatingsChannel.send(

--- a/core/commons/build.gradle.kts
+++ b/core/commons/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
   implementation(libs.timber)
 
   implementation(libs.kotlinx.datetime)
+  implementation(libs.androidx.browser)
 
   testImplementation(projects.core.testing)
 }

--- a/core/commons/src/main/kotlin/com/divinelink/core/commons/extensions/StringExtensions.kt
+++ b/core/commons/src/main/kotlin/com/divinelink/core/commons/extensions/StringExtensions.kt
@@ -26,7 +26,7 @@ fun String?.extractDetailsFromDeepLink(): Pair<Int, String>? {
   // Example URL format: "https://www.themoviedb.org/tv/693134-dune-part-two"
   return this?.let {
     val segments = it.split("/")
-    if (segments.size >= 4) {
+    if (segments.size in 4..5) {
       val mediaType = segments[3]
       val id = segments[4].substringBefore("-").toIntOrNull()
       id?.let { safeId ->

--- a/core/commons/src/main/kotlin/com/divinelink/core/commons/util/CustomTab.kt
+++ b/core/commons/src/main/kotlin/com/divinelink/core/commons/util/CustomTab.kt
@@ -1,0 +1,24 @@
+package com.divinelink.core.commons.util
+
+import android.content.Context
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsClient
+import androidx.browser.customtabs.CustomTabsIntent
+
+fun launchCustomTab(
+  context: Context,
+  url: String,
+) {
+  val packageName = CustomTabsClient.getPackageName(context, null)
+
+  val customTabsIntent = CustomTabsIntent.Builder()
+    .setColorScheme(CustomTabsIntent.COLOR_SCHEME_SYSTEM)
+    .setShowTitle(true)
+    .build()
+
+  if (packageName != null) {
+    customTabsIntent.intent.setPackage(packageName)
+  }
+
+  customTabsIntent.launchUrl(context, Uri.parse(url))
+}

--- a/core/commons/src/main/kotlin/com/divinelink/core/commons/util/CustomTab.kt
+++ b/core/commons/src/main/kotlin/com/divinelink/core/commons/util/CustomTab.kt
@@ -4,7 +4,9 @@ import android.content.Context
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
+import com.divinelink.core.commons.ExcludeFromKoverReport
 
+@ExcludeFromKoverReport
 fun launchCustomTab(
   context: Context,
   url: String,

--- a/core/model/src/main/kotlin/com/divinelink/core/model/details/MediaDetails.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/details/MediaDetails.kt
@@ -60,7 +60,6 @@ sealed class MediaDetails {
   }
 }
 
-// TODO Add unit tests
 fun MediaDetails.externalUrl(source: RatingSource = RatingSource.TMDB): String? {
   val mediaType = if (this is Movie) MediaType.MOVIE else MediaType.TV
 

--- a/core/model/src/main/kotlin/com/divinelink/core/model/details/MediaDetails.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/details/MediaDetails.kt
@@ -1,6 +1,7 @@
 package com.divinelink.core.model.details
 
 import com.divinelink.core.model.details.rating.RatingCount
+import com.divinelink.core.model.details.rating.RatingSource
 import com.divinelink.core.model.media.MediaType
 
 /**
@@ -59,13 +60,28 @@ sealed class MediaDetails {
   }
 }
 
-fun MediaDetails.shareUrl(): String {
-  val urlTitle = title
-    .lowercase()
-    .replace(":", "")
-    .replace(regex = "[\\s|/]".toRegex(), replacement = "-")
-
+// TODO Add unit tests
+fun MediaDetails.externalUrl(source: RatingSource = RatingSource.TMDB): String? {
   val mediaType = if (this is Movie) MediaType.MOVIE else MediaType.TV
 
-  return "https://www.themoviedb.org/${mediaType.value}/$id-$urlTitle"
+  when (source) {
+    RatingSource.TMDB -> {
+      val urlTitle = title
+        .lowercase()
+        .replace(":", "")
+        .replace(regex = "[\\s|/]".toRegex(), replacement = "-")
+
+      return "${source.url}/${mediaType.value}/$id-$urlTitle"
+    }
+    RatingSource.IMDB -> {
+      val imdbId = imdbId ?: return null
+
+      return "${source.url}/title/$imdbId"
+    }
+    RatingSource.TRAKT -> {
+      val imdbId = imdbId ?: return null
+
+      return source.url + "/${mediaType.traktPath}/" + imdbId
+    }
+  }
 }

--- a/core/model/src/main/kotlin/com/divinelink/core/model/details/MediaDetails.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/details/MediaDetails.kt
@@ -67,5 +67,5 @@ fun MediaDetails.shareUrl(): String {
 
   val mediaType = if (this is Movie) MediaType.MOVIE else MediaType.TV
 
-  return "https://themoviedb.org/${mediaType.value}/$id-$urlTitle"
+  return "https://www.themoviedb.org/${mediaType.value}/$id-$urlTitle"
 }

--- a/core/model/src/main/kotlin/com/divinelink/core/model/details/rating/RatingSource.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/details/rating/RatingSource.kt
@@ -5,10 +5,11 @@ import com.divinelink.core.model.R
 enum class RatingSource(
   val iconRes: Int,
   val value: String,
+  val url: String,
 ) {
-  TMDB(iconRes = R.drawable.core_model_ic_tmdb, value = "tmdb"),
-  IMDB(iconRes = R.drawable.core_model_ic_imdb, value = "imdb"),
-  TRAKT(iconRes = R.drawable.core_model_ic_trakt, value = "trakt"),
+  TMDB(iconRes = R.drawable.core_model_ic_tmdb, value = "tmdb", url = "https://www.themoviedb.org"),
+  IMDB(iconRes = R.drawable.core_model_ic_imdb, value = "imdb", url = "https://www.imdb.com"),
+  TRAKT(iconRes = R.drawable.core_model_ic_trakt, value = "trakt", url = "https://trakt.tv"),
   ;
 
   companion object {

--- a/core/model/src/main/kotlin/com/divinelink/core/model/media/MediaType.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/media/MediaType.kt
@@ -5,11 +5,14 @@ package com.divinelink.core.model.media
 /**
  * Represents the type of media.
  */
-enum class MediaType(val value: String) {
-  TV("tv"),
-  MOVIE("movie"),
-  PERSON("person"),
-  UNKNOWN("unknown");
+enum class MediaType(
+  val value: String,
+  val traktPath: String
+) {
+  TV(value = "tv", traktPath = "shows"),
+  MOVIE(value = "movie", traktPath = "movies"),
+  PERSON(value = "person", traktPath = "people"),
+  UNKNOWN(value = "unknown", traktPath = "unknown");
 
   companion object {
     fun from(type: String) = when (type) {

--- a/core/model/src/test/kotlin/com/divinelink/core/model/details/MediaDetailsTest.kt
+++ b/core/model/src/test/kotlin/com/divinelink/core/model/details/MediaDetailsTest.kt
@@ -12,7 +12,7 @@ class MediaDetailsTest {
       title = "Godzilla x Kong: The New Empire",
     )
 
-    val shareUrl = mediaDetails.shareUrl()
+    val shareUrl = mediaDetails.externalUrl()
 
     assertThat(
       shareUrl,
@@ -25,7 +25,7 @@ class MediaDetailsTest {
       title = "The Office: The New Empire",
     )
 
-    val shareUrl = mediaDetails.shareUrl()
+    val shareUrl = mediaDetails.externalUrl()
 
     assertThat(shareUrl).isEqualTo("https://themoviedb.org/tv/2316-the-office-the-new-empire")
   }

--- a/core/model/src/test/kotlin/com/divinelink/core/model/details/MediaDetailsTest.kt
+++ b/core/model/src/test/kotlin/com/divinelink/core/model/details/MediaDetailsTest.kt
@@ -1,6 +1,7 @@
 package com.divinelink.core.model.details
 
 import com.divinelink.core.fixtures.model.details.MediaDetailsFactory
+import com.divinelink.core.model.details.rating.RatingSource
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.Test
 
@@ -16,7 +17,7 @@ class MediaDetailsTest {
 
     assertThat(
       shareUrl,
-    ).isEqualTo("https://themoviedb.org/movie/1123-godzilla-x-kong-the-new-empire")
+    ).isEqualTo("https://www.themoviedb.org/movie/1123-godzilla-x-kong-the-new-empire")
   }
 
   @Test
@@ -27,6 +28,61 @@ class MediaDetailsTest {
 
     val shareUrl = mediaDetails.externalUrl()
 
-    assertThat(shareUrl).isEqualTo("https://themoviedb.org/tv/2316-the-office-the-new-empire")
+    assertThat(shareUrl).isEqualTo("https://www.themoviedb.org/tv/2316-the-office-the-new-empire")
+  }
+
+  @Test
+  fun `test externalUrl for IMDb with valid imdbId`() {
+    val mediaDetails = MediaDetailsFactory.FightClub().copy(
+      imdbId = "tt0137523",
+    )
+
+    val externalUrl = mediaDetails.externalUrl(source = RatingSource.IMDB)
+
+    assertThat(externalUrl).isEqualTo("https://www.imdb.com/title/tt0137523")
+  }
+
+  @Test
+  fun `test externalUrl for IMDb with invalid imdbId`() {
+    val mediaDetails = MediaDetailsFactory.FightClub().copy(
+      imdbId = null,
+    )
+
+    val externalUrl = mediaDetails.externalUrl(source = RatingSource.IMDB)
+
+    assertThat(externalUrl).isNull()
+  }
+
+  @Test
+  fun `test externalUrl for Trakt for movie with valid imdbId`() {
+    val mediaDetails = MediaDetailsFactory.FightClub().copy(
+      imdbId = "tt0137523",
+    )
+
+    val externalUrl = mediaDetails.externalUrl(source = RatingSource.TRAKT)
+
+    assertThat(externalUrl).isEqualTo("https://trakt.tv/movies/tt0137523")
+  }
+
+  @Test
+  fun `test externalUrl for Trakt for movie with invalid imdbId`() {
+    val mediaDetails = MediaDetailsFactory.FightClub().copy(
+      imdbId = null,
+    )
+
+    val externalUrl = mediaDetails.externalUrl(source = RatingSource.TRAKT)
+
+    assertThat(externalUrl).isNull()
+  }
+
+  @Test
+  fun `test externalUrl for Trakt for tv show with valid imdbId`() {
+    val mediaDetails = MediaDetailsFactory.TheOffice().copy(
+      imdbId = "tt0386676",
+    )
+
+    val externalUrl = mediaDetails.externalUrl(source = RatingSource.TRAKT)
+
+    assertThat(externalUrl).isEqualTo("https://trakt.tv/shows/tt0386676")
   }
 }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/DetailsDropdownMenu.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/DetailsDropdownMenu.kt
@@ -17,7 +17,7 @@ import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.fixtures.model.details.MediaDetailsFactory
 import com.divinelink.core.model.details.DetailsMenuOptions
 import com.divinelink.core.model.details.MediaDetails
-import com.divinelink.core.model.details.shareUrl
+import com.divinelink.core.model.details.externalUrl
 import com.divinelink.core.ui.components.dropdownmenu.ObfuscateSpoilersMenuItem
 import com.divinelink.core.ui.components.dropdownmenu.ShareMenuItem
 
@@ -35,7 +35,7 @@ fun DetailsDropdownMenu(
   if (showShareDialog) {
     val shareIntent = Intent(Intent.ACTION_SEND).apply {
       type = "text/plain"
-      putExtra(Intent.EXTRA_TEXT, mediaDetails.shareUrl())
+      putExtra(Intent.EXTRA_TEXT, mediaDetails.externalUrl())
     }
     LocalContext.current.startActivity(Intent.createChooser(shareIntent, "Share via"))
     showShareDialog = false

--- a/feature/details/build.gradle.kts
+++ b/feature/details/build.gradle.kts
@@ -21,6 +21,8 @@ dependencies {
   implementation(projects.core.model)
   implementation(projects.core.navigation)
 
+  implementation(libs.androidx.browser)
+
   implementation(projects.core.fixtures)
   testImplementation(projects.core.testing)
 }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
@@ -10,7 +10,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import com.divinelink.core.commons.util.launchCustomTab
 import com.divinelink.core.navigation.arguments.CreditsNavArguments
 import com.divinelink.core.navigation.arguments.DetailsNavArguments
 import com.divinelink.core.navigation.arguments.map
@@ -47,6 +49,7 @@ fun DetailsScreen(
   val viewState = viewModel.viewState.collectAsState()
   var openBottomSheet by rememberSaveable { mutableStateOf(false) }
   var showAllRatingBottomSheet by rememberSaveable { mutableStateOf(false) }
+  val context = LocalContext.current
 
   LaunchedEffect(viewState.value.navigateToLogin) {
     viewState.value.navigateToLogin?.let {
@@ -77,6 +80,12 @@ fun DetailsScreen(
     }
   }
 
+  LaunchedEffect(Unit) {
+    viewModel.openUrlTab.collect { url ->
+      launchCustomTab(context, url)
+    }
+  }
+
   if (openBottomSheet) {
     RateModalBottomSheet(
       modifier = Modifier.testTag(TestTags.Details.RATE_DIALOG),
@@ -99,9 +108,7 @@ fun DetailsScreen(
         sheetState = allRatingsBottomSheetState,
         onDismissRequest = { showAllRatingBottomSheet = false },
         ratingCount = ratingCount,
-        onClick = { ratingSource ->
-          // TODO Navigate to corresponding rating source
-        },
+        onClick = viewModel::onRatingClick,
       )
     }
   }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
@@ -108,7 +108,7 @@ fun DetailsScreen(
         sheetState = allRatingsBottomSheetState,
         onDismissRequest = { showAllRatingBottomSheet = false },
         ratingCount = ratingCount,
-        onClick = viewModel::onRatingClick,
+        onClick = viewModel::onMediaSourceClick,
       )
     }
   }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
@@ -136,7 +136,7 @@ fun DetailsScreen(
     },
     viewAllRatingsClicked = {
       showAllRatingBottomSheet = true
-      viewModel.onFetchAllRating()
+      viewModel.onFetchAllRatings()
     },
   )
 }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -31,16 +31,17 @@ import com.divinelink.feature.details.media.usecase.GetMediaDetailsUseCase
 import com.divinelink.feature.details.media.usecase.SubmitRatingParameters
 import com.divinelink.feature.details.media.usecase.SubmitRatingUseCase
 import com.divinelink.feature.details.screens.destinations.DetailsScreenDestination
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -69,8 +70,8 @@ class DetailsViewModel(
   )
   val viewState: StateFlow<DetailsViewState> = _viewState.asStateFlow()
 
-  private val _openUrlTab = MutableSharedFlow<String>()
-  val openUrlTab = _openUrlTab.asSharedFlow()
+  private val _openUrlTab = Channel<String>()
+  val openUrlTab: Flow<String> = _openUrlTab.receiveAsFlow()
 
   fun onMarkAsFavorite() {
     viewModelScope.launch {
@@ -448,13 +449,13 @@ class DetailsViewModel(
     }
   }
 
-  fun onRatingClick(source: RatingSource) {
+  fun onMediaSourceClick(source: RatingSource) {
     val mediaDetails = viewState.value.mediaDetails ?: return
     val url = mediaDetails.externalUrl(source) ?: return
 
     viewModelScope.launch {
       if (url.isNotEmpty()) {
-        _openUrlTab.emit(url)
+        _openUrlTab.send(url)
       }
     }
   }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -15,6 +15,8 @@ import com.divinelink.core.domain.credits.SpoilersObfuscationUseCase
 import com.divinelink.core.domain.details.media.FetchAllRatingsUseCase
 import com.divinelink.core.domain.jellyseerr.RequestMediaUseCase
 import com.divinelink.core.model.account.AccountMediaDetails
+import com.divinelink.core.model.details.externalUrl
+import com.divinelink.core.model.details.rating.RatingSource
 import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.navigation.arguments.DetailsNavArguments
 import com.divinelink.core.network.media.model.details.DetailsRequestApi
@@ -29,8 +31,10 @@ import com.divinelink.feature.details.media.usecase.GetMediaDetailsUseCase
 import com.divinelink.feature.details.media.usecase.SubmitRatingParameters
 import com.divinelink.feature.details.media.usecase.SubmitRatingUseCase
 import com.divinelink.feature.details.screens.destinations.DetailsScreenDestination
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.launchIn
@@ -64,6 +68,9 @@ class DetailsViewModel(
     ),
   )
   val viewState: StateFlow<DetailsViewState> = _viewState.asStateFlow()
+
+  private val _openUrlTab = MutableSharedFlow<String>()
+  val openUrlTab = _openUrlTab.asSharedFlow()
 
   fun onMarkAsFavorite() {
     viewModelScope.launch {
@@ -437,6 +444,17 @@ class DetailsViewModel(
               Timber.e(error)
             }
         }
+      }
+    }
+  }
+
+  fun onRatingClick(source: RatingSource) {
+    val mediaDetails = viewState.value.mediaDetails ?: return
+    val url = mediaDetails.externalUrl(source) ?: return
+
+    viewModelScope.launch {
+      if (url.isNotEmpty()) {
+        _openUrlTab.emit(url)
       }
     }
   }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -417,7 +417,7 @@ class DetailsViewModel(
     }
   }
 
-  fun onFetchAllRating() {
+  fun onFetchAllRatings() {
     viewModelScope.launch {
       viewState.value.mediaDetails?.let {
         fetchAllRatingsUseCase(it).collect { result ->
@@ -450,7 +450,6 @@ class DetailsViewModel(
   }
 
   // Consumers
-
   fun consumeNavigateToLogin() {
     _viewState.update { viewState ->
       viewState.copy(navigateToLogin = null)

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/person/ui/PersonViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/person/ui/PersonViewModel.kt
@@ -53,6 +53,7 @@ class PersonViewModel(
                     personDetails = PersonDetailsUiState.Data.Visible(
                       detailsResult.personDetails,
                     ),
+                    isLoading = false,
                   )
                 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ coil = "3.0.4"
 junit = "4.13.2"
 androidx-test-ext-junit = "1.2.1"
 androidx-tracing = "1.3.0-alpha02"
+androidx-browser = "1.8.0"
 lifecycle-runtime-ktx = "2.8.6"
 activity-compose = "1.9.2"
 start-up = "1.2.0"
@@ -78,6 +79,7 @@ androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = 
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
 androidx-startup = { group = "androidx.startup", name = "startup-runtime", version.ref = "start-up" }
 androidx-tracing-ktx = { group = "androidx.tracing", name = "tracing-ktx", version.ref = "androidx-tracing" }
+androidx-browser = { group = "androidx.browser", name = "browser", version.ref = "androidx-browser" }
 
 kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }


### PR DESCRIPTION
This pull request enables opening external media sources (IMDb, Trakt, TMDb) in a new custom tab by clicking their respective ratings, using the user's preferred browser option (e.g., Chrome, Brave).

Additionally, it resolves an issue where personal details remained stuck in a loading state after navigating to the screen via a deep link.

### 🎥  Video Recording 

https://github.com/user-attachments/assets/6ecdb55c-db54-4638-9a6d-ab0d56c45e84
