### PR TITLE
Add Privacy Policy on Settings

### DIFF
--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/help/HelpSettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/help/HelpSettingsScreen.kt
@@ -9,6 +9,7 @@ import com.divinelink.core.commons.DefaultBuildConfigProvider
 import com.divinelink.core.ui.UIText
 import com.divinelink.core.ui.getString
 import com.divinelink.feature.settings.R
+import com.divinelink.feature.settings.components.SettingsExternalLinkItem
 import com.divinelink.feature.settings.components.SettingsScaffold
 import com.divinelink.feature.settings.components.SettingsTextItem
 import com.divinelink.feature.settings.navigation.SettingsGraph
@@ -23,7 +24,7 @@ fun HelpSettingsScreen(
   buildConfigProvider: BuildConfigProvider = DefaultBuildConfigProvider,
 ) {
   SettingsScaffold(
-    title = stringResource(id = R.string.HelpSettingsFragment__help),
+    title = stringResource(R.string.feature_settings_help),
     onNavigationClick = navigator::navigateUp,
   ) { paddingValues ->
 
@@ -38,8 +39,13 @@ fun HelpSettingsScreen(
     LazyColumn(contentPadding = paddingValues) {
       item {
         SettingsTextItem(
-          title = stringResource(id = R.string.HelpSettingsFragment__version),
+          title = stringResource(R.string.feature_settings_help__version),
           summary = buildVersion.getString(),
+        )
+
+        SettingsExternalLinkItem(
+          text = stringResource(R.string.feature_settings_help__privacy_policy),
+          url = stringResource(R.string.feature_settings_help__privacy_policy_url),
         )
       }
     }

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/components/SettingsExternalLinkItem.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/components/SettingsExternalLinkItem.kt
@@ -1,13 +1,13 @@
 package com.divinelink.feature.settings.components
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.AutoAwesome
+import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -15,47 +15,39 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.platform.LocalContext
+import com.divinelink.core.commons.util.launchCustomTab
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.designsystem.theme.dimensions
-import com.divinelink.core.ui.IconWrapper
 import com.divinelink.core.ui.Previews
 
 @Composable
-fun SettingsClickItem(
+fun SettingsExternalLinkItem(
   modifier: Modifier = Modifier,
-  icon: IconWrapper? = null,
   text: String,
-  onClick: () -> Unit,
+  url: String,
 ) {
+  val context = LocalContext.current
+
   Row(
     verticalAlignment = Alignment.CenterVertically,
     horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_16),
     modifier = modifier
-      .clickable { onClick() }
+      .clickable { launchCustomTab(context = context, url = url) }
       .padding(MaterialTheme.dimensions.keyline_16)
       .fillMaxWidth(),
   ) {
-    icon?.let {
-      when (icon) {
-        is IconWrapper.Image -> Image(
-          painter = painterResource(id = icon.resourceId),
-          contentDescription = null,
-        )
-        is IconWrapper.Icon -> Icon(
-          painter = painterResource(id = icon.resourceId),
-          contentDescription = null,
-        )
-        is IconWrapper.Vector -> Icon(
-          imageVector = icon.vector,
-          contentDescription = null,
-        )
-      }
-    }
-
     Text(
       text = text,
       style = MaterialTheme.typography.bodyLarge,
+    )
+
+    Spacer(modifier = Modifier.weight(1f))
+
+    Icon(
+      modifier = Modifier.padding(end = MaterialTheme.dimensions.keyline_8),
+      imageVector = Icons.AutoMirrored.Filled.OpenInNew,
+      contentDescription = null,
     )
   }
 }
@@ -65,10 +57,9 @@ fun SettingsClickItem(
 private fun SettingsScreenPreview() {
   AppTheme {
     Surface {
-      SettingsClickItem(
-        icon = IconWrapper.Vector(Icons.Outlined.AutoAwesome),
-        text = "Appearance",
-        onClick = {},
+      SettingsExternalLinkItem(
+        text = "Privacy Policy",
+        url = "https://www.scenepeek.com/privacy-policy",
       )
     }
   }

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -57,9 +57,10 @@
   <string name="feature_settings_jellyseerr_joined_on">Joined on %s | User ID: %s</string>
 
   <!-- HelpSettingsScreen -->
-  <string name="HelpSettingsFragment__help">Help</string>
-  <string name="HelpSettingsFragment__terms_amp_privacy_policy">Terms &amp; Privacy Policy</string>
-  <string name="HelpSettingsFragment__version">Version</string>
+  <string name="feature_settings_help">Help</string>
+  <string name="feature_settings_help__privacy_policy">Privacy Policy</string>
+  <string name="feature_settings_help__privacy_policy_url">https://scenepeek.github.io/privacy-policy</string>
+  <string name="feature_settings_help__version">Version</string>
 
   <!-- DetailPreferencesSettingsScreen -->
   <string name="feature_settings_ratings">Ratings</string>

--- a/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/help/HelpSettingsScreenTest.kt
+++ b/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/help/HelpSettingsScreenTest.kt
@@ -43,11 +43,11 @@ class HelpSettingsScreenTest : ComposeTest() {
     val version = getString(CommonR.string.version_name) + " debug"
 
     with(composeTestRule) {
-      onNodeWithText(getString(R.string.HelpSettingsFragment__help))
+      onNodeWithText(getString(R.string.feature_settings_help))
         .assertIsDisplayed()
         .assertTextEquals("Help")
 
-      onNodeWithText(getString(R.string.HelpSettingsFragment__version)).assertIsDisplayed()
+      onNodeWithText(getString(R.string.feature_settings_help__version)).assertIsDisplayed()
       onNodeWithText(version).assertIsDisplayed()
     }
   }
@@ -64,8 +64,22 @@ class HelpSettingsScreenTest : ComposeTest() {
     val version = getString(CommonR.string.version_name)
 
     with(composeTestRule) {
-      onNodeWithText(getString(R.string.HelpSettingsFragment__version)).assertIsDisplayed()
+      onNodeWithText(getString(R.string.feature_settings_help__version)).assertIsDisplayed()
       onNodeWithText(version).assertIsDisplayed()
+    }
+  }
+
+  @Test
+  fun `test privacy policy is visible`() {
+    setContentWithTheme {
+      HelpSettingsScreen(
+        navigator = FakeDestinationsNavigator(),
+        buildConfigProvider = releaseBuildConfigProvider,
+      )
+    }
+
+    with(composeTestRule) {
+      onNodeWithText(getString(R.string.feature_settings_help__privacy_policy)).assertIsDisplayed()
     }
   }
 


### PR DESCRIPTION
This pull request adds the application's [Privacy Policy](https://scenepeek.github.io/privacy-policy/) on the Settings -> Help section. When the user clicks on the tab they ge redirected to the url using a chrome tab. 