### PR TITLE
[Performance] Fix recompositions issues due to scrollable toolbar 

### DIFF
--- a/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/FlatMediaList.kt
+++ b/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/FlatMediaList.kt
@@ -101,11 +101,7 @@ fun FlatMediaList(
       }
     }
 
-    item(
-      span = {
-        GridItemSpan(maxLineSpan)
-      },
-    ) {
+    item(span = { GridItemSpan(maxLineSpan) }) {
       AnimatedVisibility(
         visible = isLoading,
       ) {

--- a/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/HomeContent.kt
+++ b/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/HomeContent.kt
@@ -4,29 +4,13 @@ package com.divinelink.scenepeek.home.ui
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.consumeWindowInsets
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.stringResource
 import com.divinelink.core.designsystem.theme.AppTheme
-import com.divinelink.core.designsystem.theme.SearchBarShape
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.model.home.HomeMode
 import com.divinelink.core.model.home.HomePage
@@ -37,113 +21,71 @@ import com.divinelink.core.ui.blankslate.BlankSlate
 import com.divinelink.core.ui.components.Filter
 import com.divinelink.core.ui.components.FilterBar
 import com.divinelink.core.ui.components.LoadingContent
-import com.divinelink.core.ui.components.ScenePeekSearchBar
-import com.divinelink.scenepeek.R
 import com.divinelink.scenepeek.ui.composables.transitionspec.fadeTransitionSpec
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeContent(
   viewState: HomeViewState,
   modifier: Modifier = Modifier,
   onMarkAsFavoriteClicked: (MediaItem) -> Unit,
-  onSearchMovies: (String) -> Unit,
-  onClearClicked: () -> Unit,
   onLoadNextPage: () -> Unit,
   onNavigateToDetails: (MediaItem) -> Unit,
   onFilterClick: (Filter) -> Unit,
   onClearFiltersClick: () -> Unit,
   onRetryClick: () -> Unit,
-  onNavigateToSettings: () -> Unit,
 ) {
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
+  AnimatedVisibility(visible = viewState.query.isEmpty()) {
+    FilterBar(
+      modifier = modifier
+        .padding(
+          horizontal = MaterialTheme.dimensions.keyline_8,
+          vertical = MaterialTheme.dimensions.keyline_4,
+        ),
+      filters = viewState.filters,
+      onFilterClick = onFilterClick,
+      onClearClick = onClearFiltersClick,
+    )
+  }
 
-  Scaffold(
-    modifier = Modifier
-      .nestedScroll(scrollBehavior.nestedScrollConnection)
-      .navigationBarsPadding(),
-    topBar = {
-      ScenePeekSearchBar(
-        scrollBehavior = scrollBehavior,
-        modifier = Modifier
-          .navigationBarsPadding()
-          .clip(SearchBarShape),
-        actions = {
-          IconButton(onClick = onNavigateToSettings) {
-            Icon(
-              Icons.Filled.Settings,
-              stringResource(R.string.settings_button_content_description),
-            )
-          }
-        },
-        isLoading = viewState.isSearchLoading,
-        query = viewState.query,
-        onSearchFieldChanged = { query ->
-          onSearchMovies(query)
-        },
-        onClearClicked = onClearClicked,
-      )
-    },
-  ) { paddingValues ->
-    Column(
-      modifier = Modifier
-        .consumeWindowInsets(paddingValues)
-        .padding(paddingValues),
-    ) {
-      AnimatedVisibility(visible = viewState.query.isEmpty()) {
-        FilterBar(
-          modifier = modifier
-            .padding(
-              horizontal = MaterialTheme.dimensions.keyline_8,
-              vertical = MaterialTheme.dimensions.keyline_4,
-            ),
-          filters = viewState.filters,
-          onFilterClick = onFilterClick,
-          onClearClick = onClearFiltersClick,
+  AnimatedContent(
+    targetState = viewState.isEmpty,
+    transitionSpec = fadeTransitionSpec(),
+    label = "HomeContentEmptyTransition",
+  ) { isEmpty ->
+    when (isEmpty) {
+      true -> if (viewState.blankSlate != null) {
+        BlankSlate(
+          uiState = viewState.blankSlate,
+          onRetry = viewState.retryAction?.let { onRetryClick },
         )
       }
-
-      AnimatedContent(
-        targetState = viewState.isEmpty,
+      false -> AnimatedContent(
+        targetState = viewState.mode,
         transitionSpec = fadeTransitionSpec(),
-        label = "HomeContentEmptyTransition",
-      ) { isEmpty ->
-        when (isEmpty) {
-          true -> if (viewState.blankSlate != null) {
-            BlankSlate(
-              uiState = viewState.blankSlate,
-              onRetry = viewState.retryAction?.let { onRetryClick },
-            )
-          }
-          false -> AnimatedContent(
-            targetState = viewState.mode,
-            transitionSpec = fadeTransitionSpec(),
-            label = "HomeContentTransition",
-          ) { mode ->
-            when (mode) {
-              HomeMode.Browser -> MediaContent(
-                modifier = modifier,
-                section = viewState.popularMovies,
-                onMediaClick = onNavigateToDetails,
-                onMarkAsFavoriteClick = onMarkAsFavoriteClicked,
-                onLoadNextPage = onLoadNextPage,
-              )
-              HomeMode.Search -> MediaContent(
-                modifier = modifier,
-                section = viewState.searchResults,
-                onMediaClick = onNavigateToDetails,
-                onMarkAsFavoriteClick = onMarkAsFavoriteClicked,
-                onLoadNextPage = onLoadNextPage,
-              )
-              HomeMode.Filtered -> MediaContent(
-                modifier = modifier,
-                section = viewState.filteredResults,
-                onMediaClick = onNavigateToDetails,
-                onMarkAsFavoriteClick = onMarkAsFavoriteClicked,
-                onLoadNextPage = onLoadNextPage,
-              )
-            }
-          }
+        label = "HomeContentTransition",
+      ) { mode ->
+        when (mode) {
+          HomeMode.Browser -> MediaContent(
+            modifier = modifier,
+            section = viewState.popularMovies,
+            onMediaClick = onNavigateToDetails,
+            onMarkAsFavoriteClick = onMarkAsFavoriteClicked,
+            onLoadNextPage = onLoadNextPage,
+          )
+          HomeMode.Search -> MediaContent(
+            modifier = modifier,
+            section = viewState.searchResults,
+            onMediaClick = onNavigateToDetails,
+            onMarkAsFavoriteClick = onMarkAsFavoriteClicked,
+            onLoadNextPage = onLoadNextPage,
+          )
+          HomeMode.Filtered -> MediaContent(
+            modifier = modifier,
+            section = viewState.filteredResults,
+            onMediaClick = onNavigateToDetails,
+            onMarkAsFavoriteClick = onMarkAsFavoriteClicked,
+            onLoadNextPage = onLoadNextPage,
+          )
         }
       }
     }
@@ -164,9 +106,7 @@ private fun MediaContent(
   if (section == null) return
 
   FlatMediaList(
-    modifier = modifier
-      .fillMaxSize()
-      .testTag(MEDIA_LIST_TAG),
+    modifier = modifier.testTag(MEDIA_LIST_TAG),
     data = section.data,
     onItemClick = onMediaClick,
     onMarkAsFavoriteClicked = onMarkAsFavoriteClick,
@@ -227,12 +167,9 @@ private fun HomeContentPreview() {
         ),
         onMarkAsFavoriteClicked = {},
         onLoadNextPage = {},
-        onSearchMovies = {},
-        onClearClicked = {},
         onNavigateToDetails = {},
         onFilterClick = {},
         onClearFiltersClick = {},
-        onNavigateToSettings = {},
         onRetryClick = {},
       )
     }

--- a/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/HomeScreen.kt
+++ b/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/HomeScreen.kt
@@ -1,66 +1,98 @@
 package com.divinelink.scenepeek.home.ui
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.divinelink.core.designsystem.theme.SearchBarShape
 import com.divinelink.core.model.media.MediaItem
 import com.divinelink.core.navigation.arguments.DetailsNavArguments
 import com.divinelink.core.navigation.arguments.PersonNavArguments
+import com.divinelink.core.ui.components.ScenePeekSearchBar
+import com.divinelink.core.ui.components.scaffold.AppScaffold
 import com.divinelink.feature.details.screens.destinations.DetailsScreenDestination
 import com.divinelink.feature.details.screens.destinations.PersonScreenDestination
 import com.divinelink.feature.settings.screens.destinations.SettingsScreenDestination
+import com.divinelink.scenepeek.R
 import com.divinelink.scenepeek.navigation.MainGraph
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import org.koin.androidx.compose.koinViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Destination<MainGraph>(start = true)
 @Composable
 fun HomeScreen(
   navigator: DestinationsNavigator,
   viewModel: HomeViewModel = koinViewModel(),
 ) {
-  val viewState = viewModel.viewState.collectAsState()
+  val viewState = viewModel.viewState.collectAsStateWithLifecycle().value
 
-  HomeContent(
-    modifier = Modifier,
-    viewState = viewState.value,
-    onMarkAsFavoriteClicked = viewModel::onMarkAsFavoriteClicked,
-    onLoadNextPage = viewModel::onLoadNextPage,
-    onSearchMovies = viewModel::onSearchMovies,
-    onClearClicked = viewModel::onClearClicked,
-    onNavigateToDetails = { media ->
-      val destination = when (media) {
-        is MediaItem.Media -> {
-          val navArgs = DetailsNavArguments(
-            id = media.id,
-            mediaType = media.mediaType.value,
-            isFavorite = media.isFavorite,
-          )
-          DetailsScreenDestination(navArgs = navArgs)
-        }
-        is MediaItem.Person -> {
-          PersonScreenDestination(
-            navArgs = PersonNavArguments(
-              id = media.id.toLong(),
-              knownForDepartment = media.knownForDepartment,
-              name = media.name,
-              profilePath = media.profilePath,
-              gender = media.gender,
-            ),
-          )
-        }
-        else -> {
-          return@HomeContent
-        }
-      }
-      navigator.navigate(destination)
+  AppScaffold(
+    topBar = { scrollBehavior, _ ->
+      ScenePeekSearchBar(
+        scrollBehavior = scrollBehavior,
+        modifier = Modifier.clip(SearchBarShape),
+        actions = {
+          IconButton(
+            onClick = {
+              navigator.navigate(SettingsScreenDestination())
+            },
+          ) {
+            Icon(
+              imageVector = Icons.Filled.Settings,
+              contentDescription = stringResource(R.string.settings_button_content_description),
+            )
+          }
+        },
+        isLoading = viewState.isSearchLoading,
+        query = viewState.query,
+        onSearchFieldChanged = viewModel::onSearchMovies,
+        onClearClicked = viewModel::onClearClicked,
+      )
     },
-    onFilterClick = viewModel::onFilterClick,
-    onClearFiltersClick = viewModel::onClearFiltersClicked,
-    onNavigateToSettings = {
-      navigator.navigate(SettingsScreenDestination())
-    },
-    onRetryClick = viewModel::onRetryClick,
-  )
+  ) {
+    HomeContent(
+      modifier = Modifier,
+      viewState = viewState,
+      onMarkAsFavoriteClicked = viewModel::onMarkAsFavoriteClicked,
+      onLoadNextPage = viewModel::onLoadNextPage,
+      onNavigateToDetails = { media ->
+        val destination = when (media) {
+          is MediaItem.Media -> {
+            val navArgs = DetailsNavArguments(
+              id = media.id,
+              mediaType = media.mediaType.value,
+              isFavorite = media.isFavorite,
+            )
+            DetailsScreenDestination(navArgs = navArgs)
+          }
+          is MediaItem.Person -> {
+            PersonScreenDestination(
+              navArgs = PersonNavArguments(
+                id = media.id.toLong(),
+                knownForDepartment = media.knownForDepartment,
+                name = media.name,
+                profilePath = media.profilePath,
+                gender = media.gender,
+              ),
+            )
+          }
+          else -> {
+            return@HomeContent
+          }
+        }
+        navigator.navigate(destination)
+      },
+      onFilterClick = viewModel::onFilterClick,
+      onClearFiltersClick = viewModel::onClearFiltersClicked,
+      onRetryClick = viewModel::onRetryClick,
+    )
+  }
 }

--- a/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/HomeViewState.kt
+++ b/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/HomeViewState.kt
@@ -1,5 +1,6 @@
 package com.divinelink.scenepeek.home.ui
 
+import androidx.compose.runtime.Immutable
 import com.divinelink.core.model.home.HomeMode
 import com.divinelink.core.model.home.HomePage
 import com.divinelink.core.ui.UIText
@@ -8,6 +9,7 @@ import com.divinelink.core.ui.components.Filter
 import com.divinelink.scenepeek.R
 import com.divinelink.core.ui.R as uiR
 
+@Immutable
 data class HomeViewState(
   val isLoading: Boolean,
   val filters: List<Filter>,

--- a/app/src/test/kotlin/com/divinelink/ui/home/HomeContentTest.kt
+++ b/app/src/test/kotlin/com/divinelink/ui/home/HomeContentTest.kt
@@ -29,14 +29,11 @@ class HomeContentTest : ComposeTest() {
       HomeContent(
         viewState = uiState,
         onMarkAsFavoriteClicked = {},
-        onSearchMovies = {},
-        onClearClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
         onClearFiltersClick = {},
-        onRetryClick = { },
-        onNavigateToSettings = {},
+        onRetryClick = {},
       )
     }
 
@@ -58,14 +55,11 @@ class HomeContentTest : ComposeTest() {
       HomeContent(
         viewState = uiState,
         onMarkAsFavoriteClicked = {},
-        onSearchMovies = {},
-        onClearClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
         onClearFiltersClick = {},
         onRetryClick = { onRetryClicked = true },
-        onNavigateToSettings = {},
       )
     }
 
@@ -90,14 +84,11 @@ class HomeContentTest : ComposeTest() {
       HomeContent(
         viewState = uiState,
         onMarkAsFavoriteClicked = {},
-        onSearchMovies = {},
-        onClearClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
         onClearFiltersClick = {},
-        onRetryClick = { },
-        onNavigateToSettings = {},
+        onRetryClick = {},
       )
     }
 
@@ -118,14 +109,11 @@ class HomeContentTest : ComposeTest() {
       HomeContent(
         viewState = uiState,
         onMarkAsFavoriteClicked = {},
-        onSearchMovies = {},
-        onClearClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
         onClearFiltersClick = {},
-        onRetryClick = { },
-        onNavigateToSettings = {},
+        onRetryClick = {},
       )
     }
 
@@ -150,14 +138,11 @@ class HomeContentTest : ComposeTest() {
       HomeContent(
         viewState = uiState,
         onMarkAsFavoriteClicked = {},
-        onSearchMovies = {},
-        onClearClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
         onClearFiltersClick = {},
-        onRetryClick = { },
-        onNavigateToSettings = {},
+        onRetryClick = {},
       )
     }
 
@@ -190,14 +175,11 @@ class HomeContentTest : ComposeTest() {
       HomeContent(
         viewState = uiState,
         onMarkAsFavoriteClicked = {},
-        onSearchMovies = {},
-        onClearClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
         onClearFiltersClick = {},
-        onRetryClick = { },
-        onNavigateToSettings = {},
+        onRetryClick = {},
       )
     }
 
@@ -230,14 +212,11 @@ class HomeContentTest : ComposeTest() {
       HomeContent(
         viewState = uiState,
         onMarkAsFavoriteClicked = {},
-        onSearchMovies = {},
-        onClearClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
         onClearFiltersClick = {},
-        onRetryClick = { },
-        onNavigateToSettings = {},
+        onRetryClick = {},
       )
     }
 

--- a/core/network/src/main/kotlin/com/divinelink/core/network/media/model/details/DetailsResponseApi.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/media/model/details/DetailsResponseApi.kt
@@ -174,7 +174,8 @@ private fun Int?.toHourMinuteFormat(): String? {
     val remainingMinutes = minutes % 60
     return when {
       hours > 0 -> "${hours}h ${remainingMinutes}m"
-      else -> "${remainingMinutes}m"
+      remainingMinutes > 0 -> "${remainingMinutes}m"
+      else -> null
     }
   }
 }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/scaffold/AppScaffold.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/scaffold/AppScaffold.kt
@@ -1,15 +1,16 @@
 package com.divinelink.core.ui.components.scaffold
 
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
-import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -19,9 +20,9 @@ import androidx.compose.ui.input.nestedscroll.nestedScroll
 fun AppScaffold(
   modifier: Modifier = Modifier,
   topBar: @Composable (TopAppBarScrollBehavior, TopAppBarColors) -> Unit = { _, _ -> },
-  content: @Composable (PaddingValues) -> Unit,
+  content: @Composable () -> Unit,
 ) {
-  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(rememberTopAppBarState())
+  val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()
   val topAppBarColor = TopAppBarDefaults.topAppBarColors(
     scrolledContainerColor = MaterialTheme.colorScheme.surface,
   )
@@ -29,10 +30,14 @@ fun AppScaffold(
   Scaffold(
     modifier = modifier
       .fillMaxSize()
-      .navigationBarsPadding()
-      .nestedScroll(scrollBehavior.nestedScrollConnection),
+      .nestedScroll(scrollBehavior.nestedScrollConnection)
+      .navigationBarsPadding(),
     topBar = { topBar(scrollBehavior, topAppBarColor) },
   ) { paddingValues ->
-    content(paddingValues)
+    Column {
+      Spacer(modifier = Modifier.padding(top = paddingValues.calculateTopPadding()))
+
+      content()
+    }
   }
 }

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsScreen.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/CreditsScreen.kt
@@ -1,6 +1,5 @@
 package com.divinelink.feature.credits.ui
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -11,7 +10,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import com.divinelink.core.model.details.Person
@@ -70,9 +68,8 @@ fun CreditsScreen(
         },
       )
     },
-  ) { paddingValues ->
+  ) {
     CreditsContent(
-      modifier = Modifier.padding(paddingValues),
       state = uiState,
       onTabSelected = viewModel::onTabSelected,
       onPersonSelected = { onNavigateToPersonDetails(it) },

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
@@ -507,55 +507,48 @@ private fun UserRating(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun TitleDetails(mediaDetails: MediaDetails) {
-  Row(
+  Column(
     modifier = Modifier
       .fillMaxWidth()
-      .padding(horizontal = MaterialTheme.dimensions.keyline_12),
+      .padding(horizontal = MaterialTheme.dimensions.keyline_12)
+      .padding(bottom = MaterialTheme.dimensions.keyline_12),
   ) {
     Text(
-      modifier = Modifier.weight(1f),
       style = MaterialTheme.typography.displaySmall,
       text = mediaDetails.title,
     )
-  }
 
-  FlowRow(
-    modifier = Modifier
-      .padding(
-        start = MaterialTheme.dimensions.keyline_16,
-        end = MaterialTheme.dimensions.keyline_12,
-        bottom = MaterialTheme.dimensions.keyline_16,
-      ),
-  ) {
-    Text(
-      style = MaterialTheme.typography.labelMedium,
-      text = mediaDetails.releaseDate,
-    )
+    FlowRow {
+      Text(
+        style = MaterialTheme.typography.labelMedium,
+        text = mediaDetails.releaseDate,
+      )
 
-    when (mediaDetails) {
-      is Movie -> mediaDetails.runtime?.let { runtime ->
-        Text(
-          style = MaterialTheme.typography.labelMedium,
-          text = " • $runtime",
-        )
-      }
-      is TV -> {
-        if (mediaDetails.status != TvStatus.UNKNOWN) {
+      when (mediaDetails) {
+        is Movie -> mediaDetails.runtime?.let { runtime ->
           Text(
             style = MaterialTheme.typography.labelMedium,
-            text = " • " + stringResource(mediaDetails.status.resId),
+            text = " • $runtime",
           )
         }
+        is TV -> {
+          if (mediaDetails.status != TvStatus.UNKNOWN) {
+            Text(
+              style = MaterialTheme.typography.labelMedium,
+              text = " • " + stringResource(mediaDetails.status.resId),
+            )
+          }
 
-        if (mediaDetails.numberOfSeasons > 0) {
-          Text(
-            style = MaterialTheme.typography.labelMedium,
-            text = " • " + pluralStringResource(
-              id = R.plurals.feature_details_number_of_seasons,
-              count = mediaDetails.numberOfSeasons,
-              mediaDetails.numberOfSeasons,
-            ),
-          )
+          if (mediaDetails.numberOfSeasons > 0) {
+            Text(
+              style = MaterialTheme.typography.labelMedium,
+              text = " • " + pluralStringResource(
+                id = R.plurals.feature_details_number_of_seasons,
+                count = mediaDetails.numberOfSeasons,
+                mediaDetails.numberOfSeasons,
+              ),
+            )
+          }
         }
       }
     }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
@@ -1,5 +1,6 @@
 package com.divinelink.feature.details.media.ui
 
+import androidx.compose.runtime.Immutable
 import com.divinelink.core.model.account.AccountMediaDetails
 import com.divinelink.core.model.credits.AggregateCredits
 import com.divinelink.core.model.details.DetailActionItem
@@ -15,6 +16,7 @@ import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.ui.UIText
 import com.divinelink.core.ui.snackbar.SnackbarMessage
 
+@Immutable
 data class DetailsViewState(
   val isLoading: Boolean = false,
   val mediaType: MediaType,

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/person/ui/PersonScreen.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/person/ui/PersonScreen.kt
@@ -2,7 +2,6 @@
 
 package com.divinelink.feature.details.person.ui
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.MoreVert
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -71,7 +70,7 @@ fun PersonScreen(
         )
       }
     },
-  ) { paddingValues ->
+  ) {
     when {
       uiState.isError -> {
         // TODO Add error content
@@ -82,7 +81,6 @@ fun PersonScreen(
           LoadingContent()
         } else {
           PersonContent(
-            modifier = Modifier.padding(paddingValues),
             uiState = uiState,
             onMediaClick = {
               navigator.navigate(

--- a/feature/watchlist/src/main/kotlin/com/divinelink/feature/watchlist/WatchlistScreen.kt
+++ b/feature/watchlist/src/main/kotlin/com/divinelink/feature/watchlist/WatchlistScreen.kt
@@ -3,12 +3,10 @@ package com.divinelink.feature.watchlist
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SecondaryTabRow
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -70,54 +68,50 @@ fun WatchlistScreen(
         },
       )
     },
-  ) { padding ->
-    Surface(
-      modifier = Modifier.padding(padding),
-    ) {
-      Column {
-        WatchlistTabs(
-          tabs = uiState.value.tabs,
-          selectedIndex = selectedPage,
-          onClick = {
-            viewModel.onTabSelected(it)
-            scope.launch {
-              pagerState.animateScrollToPage(it)
-            }
-          },
-        )
+  ) {
+    Column {
+      WatchlistTabs(
+        tabs = uiState.value.tabs,
+        selectedIndex = selectedPage,
+        onClick = {
+          viewModel.onTabSelected(it)
+          scope.launch {
+            pagerState.animateScrollToPage(it)
+          }
+        },
+      )
 
-        HorizontalPager(
-          modifier = Modifier.fillMaxSize(),
-          state = pagerState,
-        ) { page ->
-          uiState.value.forms.values.elementAt(page).let {
-            when (it) {
-              is WatchlistForm.Loading -> LoadingContent()
-              is WatchlistForm.Error -> WatchlistErrorContent(
-                error = it,
-                onLogin = onNavigateToAccountSettings,
-                onRetry = {
-                },
-              )
-              is WatchlistForm.Data -> {
-                if (it.isEmpty) {
-                  BlankSlate(uiState = BlankSlateState.Custom(title = it.emptyResultsUiText))
-                } else {
-                  WatchlistContent(
-                    list = it.data,
-                    onMediaClick = { media ->
-                      onNavigateToMediaDetails(
-                        DetailsNavArguments(
-                          mediaType = media.mediaType.value,
-                          id = media.id,
-                          isFavorite = media.isFavorite,
-                        ),
-                      )
-                    },
-                    totalResults = it.totalResultsUiText,
-                    onLoadMore = viewModel::onLoadMore,
-                  )
-                }
+      HorizontalPager(
+        modifier = Modifier.fillMaxSize(),
+        state = pagerState,
+      ) { page ->
+        uiState.value.forms.values.elementAt(page).let {
+          when (it) {
+            is WatchlistForm.Loading -> LoadingContent()
+            is WatchlistForm.Error -> WatchlistErrorContent(
+              error = it,
+              onLogin = onNavigateToAccountSettings,
+              onRetry = {
+              },
+            )
+            is WatchlistForm.Data -> {
+              if (it.isEmpty) {
+                BlankSlate(uiState = BlankSlateState.Custom(title = it.emptyResultsUiText))
+              } else {
+                WatchlistContent(
+                  list = it.data,
+                  onMediaClick = { media ->
+                    onNavigateToMediaDetails(
+                      DetailsNavArguments(
+                        mediaType = media.mediaType.value,
+                        id = media.id,
+                        isFavorite = media.isFavorite,
+                      ),
+                    )
+                  },
+                  totalResults = it.totalResultsUiText,
+                  onLoadMore = viewModel::onLoadMore,
+                )
               }
             }
           }


### PR DESCRIPTION
This pull requests addresses some performance issues by fixing recompositions due to the scrollable toolbar. 

The issue is that some padding was always applied to the content of each screen while the user scrolled through. This occurred because the scroll behavior responsible for expanding and collapsing the toolbar `val scrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior()` was dynamically changing as the toolbar state updated. To fix the recomposition issues, we introduced a static spacer at the top of the content.

```
Scaffold(
    modifier = modifier
      .fillMaxSize()
      .nestedScroll(scrollBehavior.nestedScrollConnection)
      .navigationBarsPadding(),
    topBar = { topBar(scrollBehavior, topAppBarColor) },
  ) { paddingValues ->
    Column {
      Spacer(modifier = Modifier.padding(top = paddingValues.calculateTopPadding()))
      content()
    }
  }
```