### PR TITLE
Add Scroll to Top on Person Screen & Button Behaviour and UI 

### DIFF
--- a/app/src/test/kotlin/com/divinelink/scenepeek/popular/domain/repository/ProdMediaRepositoryTest.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/popular/domain/repository/ProdMediaRepositoryTest.kt
@@ -110,21 +110,6 @@ class ProdMediaRepositoryTest {
       assertThat(expectedResult).isEqualTo(actualResult.data)
     }
 
-  //    @Test
-  //    fun testFetchPopularMoviesErrorCase() = runTest {
-  //        val request = PopularRequestApi(apiKey = "", page = 1)
-  //        val expectedResult = Result.failure(Exception("response is empty"))
-  //
-  //        mediaService.mockFetchPopularMovies(
-  //            request = request,
-  //            result = flowOf(),
-  //        )
-  //
-  //        val actualResult = repository.fetchPopularMovies(request)
-  //
-  //        assertThat(expectedResult).isInstanceOf(actualResult::class.java)
-  //    }
-
   @Test
   fun testFetchFavoriteMovies() = runTest {
     val expectedResult = listOf(

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/ScrollToTopButton.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/ScrollToTopButton.kt
@@ -1,47 +1,76 @@
 package com.divinelink.core.ui.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.EaseIn
+import androidx.compose.animation.core.EaseOut
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
 import com.divinelink.core.designsystem.theme.AppTheme
+import com.divinelink.core.designsystem.theme.LocalBottomNavigationPadding
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.ui.Previews
 import com.divinelink.core.ui.R
 import com.divinelink.core.ui.TestTags
 
 @Composable
-fun ScrollToTopButton(onClick: () -> Unit) {
-  Button(
-    modifier = Modifier
-      .testTag(TestTags.SCROLL_TO_TOP_BUTTON)
-      .shadow(MaterialTheme.dimensions.keyline_4, shape = CircleShape)
-      .size(MaterialTheme.dimensions.keyline_56)
-      .clip(shape = CircleShape),
-    contentPadding = PaddingValues(),
-    onClick = onClick,
+fun ScrollToTopButton(
+  modifier: Modifier = Modifier,
+  visible: Boolean,
+  onClick: () -> Unit,
+) {
+  AnimatedVisibility(
+    visible = visible,
+    enter = fadeIn(tween(easing = EaseIn)),
+    exit = fadeOut(tween(easing = EaseOut)),
+    modifier = modifier
+      .padding(bottom = LocalBottomNavigationPadding.current + MaterialTheme.dimensions.keyline_16),
+    label = "Show scroll to top button animation",
   ) {
-    Icon(
-      imageVector = Icons.Filled.KeyboardArrowUp,
-      contentDescription = stringResource(R.string.core_ui_scroll_to_top_button),
-    )
+    Button(
+      modifier = Modifier
+        .testTag(TestTags.SCROLL_TO_TOP_BUTTON)
+        .height(MaterialTheme.dimensions.keyline_32)
+        .clip(shape = CircleShape),
+      contentPadding = PaddingValues(horizontal = MaterialTheme.dimensions.keyline_16),
+      colors = ButtonDefaults.buttonColors().copy(
+        containerColor = MaterialTheme.colorScheme.onSurface,
+        contentColor = MaterialTheme.colorScheme.surface,
+      ),
+      onClick = onClick,
+    ) {
+      Text(
+        text = stringResource(R.string.core_ui_back_to_top),
+        style = MaterialTheme.typography.titleSmall,
+        fontWeight = FontWeight.W600,
+        fontSize = 11.5.sp,
+      )
+    }
   }
 }
 
 @Composable
 @Previews
-private fun ScrollToTopButtonPreview() {
+fun ScrollToTopButtonPreview() {
   AppTheme {
-    ScrollToTopButton {}
+    Surface {
+      ScrollToTopButton(visible = true) {}
+    }
   }
 }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/extensions/LazyState.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/extensions/LazyState.kt
@@ -77,3 +77,25 @@ fun LazyListState.EndlessScrollHandler(
       }
   }
 }
+
+@Composable
+fun LazyGridState.canScrollToTop(): Boolean {
+  val scrollToTop = remember {
+    derivedStateOf {
+      this.firstVisibleItemIndex > 3 && this.lastScrolledBackward
+    }
+  }
+
+  return scrollToTop.value
+}
+
+@Composable
+fun LazyListState.canScrollToTop(): Boolean {
+  val scrollToTop = remember {
+    derivedStateOf {
+      this.firstVisibleItemIndex > 3 && this.lastScrolledBackward
+    }
+  }
+
+  return scrollToTop.value
+}

--- a/core/ui/src/screenshotTest/kotlin/com/divinelink/core/ui/ScrollToTopButtonScreenshots.kt
+++ b/core/ui/src/screenshotTest/kotlin/com/divinelink/core/ui/ScrollToTopButtonScreenshots.kt
@@ -1,0 +1,10 @@
+package com.divinelink.core.ui
+
+import androidx.compose.runtime.Composable
+import com.divinelink.core.ui.components.ScrollToTopButtonPreview
+
+@Previews
+@Composable
+fun ScrollToTopButtonScreenshots() {
+  ScrollToTopButtonPreview()
+}

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/person/ui/PersonGridContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/person/ui/PersonGridContent.kt
@@ -1,11 +1,13 @@
 package com.divinelink.feature.details.person.ui
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -32,7 +34,6 @@ import timber.log.Timber
 @Composable
 internal fun PersonGridContent(
   modifier: Modifier = Modifier,
-  itemModifier: Modifier = Modifier,
   grid: GridCells,
   credits: GroupedPersonCredits,
   filters: List<CreditFilter>,
@@ -41,9 +42,8 @@ internal fun PersonGridContent(
   setCurrentDepartment: (String) -> Unit,
   mediaType: MediaType,
   name: String,
+  lazyGridState: LazyGridState = rememberLazyGridState(),
 ) {
-  val lazyGridState = rememberLazyGridState()
-
   val currentDepartments = credits.keys.toList()
   val headerPositions = remember(currentDepartments) {
     val positions = mutableListOf<Int>()
@@ -121,7 +121,9 @@ internal fun PersonGridContent(
         ) { item ->
           if (isGrid) {
             MediaItem(
-              modifier = itemModifier,
+              modifier = Modifier
+                .animateItem()
+                .animateContentSize(),
               media = item.mediaItem,
               subtitle = item.role.title,
               fullDate = false,
@@ -129,7 +131,9 @@ internal fun PersonGridContent(
             )
           } else {
             CreditMediaItem(
-              modifier = itemModifier,
+              modifier = Modifier
+                .animateItem()
+                .animateContentSize(),
               mediaItem = item.mediaItem,
               subtitle = item.role.title,
               onClick = onMediaClick,

--- a/feature/watchlist/build.gradle.kts
+++ b/feature/watchlist/build.gradle.kts
@@ -23,5 +23,6 @@ dependencies {
 
   implementation(libs.timber)
 
+  implementation(projects.core.fixtures)
   testImplementation(projects.core.testing)
 }

--- a/feature/watchlist/src/main/kotlin/com/divinelink/feature/watchlist/WatchlistContent.kt
+++ b/feature/watchlist/src/main/kotlin/com/divinelink/feature/watchlist/WatchlistContent.kt
@@ -1,6 +1,5 @@
 package com.divinelink.feature.watchlist
 
-import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
@@ -13,18 +12,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.datasource.LoremIpsum
 import com.divinelink.core.designsystem.component.ScenePeekLazyColumn
 import com.divinelink.core.designsystem.theme.AppTheme
-import com.divinelink.core.designsystem.theme.LocalBottomNavigationPadding
 import com.divinelink.core.designsystem.theme.dimensions
+import com.divinelink.core.fixtures.model.media.MediaItemFactory
 import com.divinelink.core.model.media.MediaItem
 import com.divinelink.core.ui.DetailedMediaItem
 import com.divinelink.core.ui.Previews
@@ -32,6 +28,7 @@ import com.divinelink.core.ui.TestTags
 import com.divinelink.core.ui.UIText
 import com.divinelink.core.ui.components.ScrollToTopButton
 import com.divinelink.core.ui.components.extensions.EndlessScrollHandler
+import com.divinelink.core.ui.components.extensions.canScrollToTop
 import com.divinelink.core.ui.getString
 import kotlinx.coroutines.launch
 
@@ -44,7 +41,6 @@ fun WatchlistContent(
 ) {
   val scrollState = rememberLazyListState()
   val scope = rememberCoroutineScope()
-  val showScrollToTop = remember { derivedStateOf { scrollState.firstVisibleItemIndex > 6 } }
 
   scrollState.EndlessScrollHandler(
     buffer = 4,
@@ -80,48 +76,26 @@ fun WatchlistContent(
         )
       }
     }
-    AnimatedContent(
-      modifier = Modifier
-        .padding(
-          end = MaterialTheme.dimensions.keyline_16,
-          bottom = LocalBottomNavigationPadding.current + MaterialTheme.dimensions.keyline_16,
-        )
-        .align(Alignment.BottomEnd),
-      targetState = showScrollToTop.value,
-      label = "Show scroll to top button animation",
-    ) { isVisible ->
-      if (isVisible) {
-        ScrollToTopButton {
-          scope.launch {
-            scrollState.animateScrollToItem(0)
-          }
+
+    ScrollToTopButton(
+      modifier = Modifier.align(Alignment.BottomCenter),
+      visible = scrollState.canScrollToTop(),
+      onClick = {
+        scope.launch {
+          scrollState.animateScrollToItem(0)
         }
-      }
-    }
+      },
+    )
   }
 }
 
 @Previews
 @Composable
-private fun WatchlistContentPreview() {
-  val movie = MediaItem.Media.Movie(
-    id = 0,
-    posterPath = "",
-    releaseDate = "2020-07-02",
-    name = "Flight Club",
-    voteAverage = 9.4,
-    voteCount = 1_333_982,
-    overview = LoremIpsum(50).values.joinToString(),
-    isFavorite = false,
-  )
-  val list = (1..10).map {
-    movie.copy(id = it)
-  }
-
+fun WatchlistContentPreview() {
   AppTheme {
     Surface {
       WatchlistContent(
-        list = list,
+        list = MediaItemFactory.MoviesList(range = 1..30),
         totalResults = UIText.StringText("You have 264 movies in your watchlist"),
         onMediaClick = {},
         onLoadMore = {},

--- a/feature/watchlist/src/screenshotTest/kotlin/com/divinelink/feature/watchlist/WatchlistContentScreenshots.kt
+++ b/feature/watchlist/src/screenshotTest/kotlin/com/divinelink/feature/watchlist/WatchlistContentScreenshots.kt
@@ -1,0 +1,10 @@
+package com.divinelink.feature.watchlist
+
+import androidx.compose.runtime.Composable
+import com.divinelink.core.ui.Previews
+
+@Composable
+@Previews
+fun WatchlistContentScreenshots() {
+  WatchlistContentPreview()
+}

--- a/feature/watchlist/src/test/kotlin/com/divinelink/feature/watchlist/WatchlistScreenTest.kt
+++ b/feature/watchlist/src/test/kotlin/com/divinelink/feature/watchlist/WatchlistScreenTest.kt
@@ -1,6 +1,7 @@
 package com.divinelink.feature.watchlist
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasText
@@ -13,7 +14,6 @@ import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.navigation.arguments.DetailsNavArguments
 import com.divinelink.core.testing.ComposeTest
 import com.divinelink.core.testing.factories.model.watchlist.WatchlistResponseFactory
-import com.divinelink.core.testing.navigator.FakeDestinationsNavigator
 import com.divinelink.core.testing.setContentWithTheme
 import com.divinelink.core.testing.usecase.FakeFetchWatchlistUseCase
 import com.divinelink.core.testing.usecase.TestObserveAccountUseCase
@@ -117,8 +117,6 @@ class WatchlistScreenTest : ComposeTest() {
 
   @Test
   fun `test watchlist with empty content`() {
-    val destinationsNavigator = FakeDestinationsNavigator()
-
     observeAccountUseCase.mockSuccess(response = Result.success(true))
     fetchWatchlistUseCase.mockSuccess(
       response = flowOf(
@@ -164,8 +162,6 @@ class WatchlistScreenTest : ComposeTest() {
 
   @Test
   fun `test tv watching is loading`() {
-    val destinationsNavigator = FakeDestinationsNavigator()
-
     observeAccountUseCase.mockSuccess(response = Result.success(true))
     fetchWatchlistUseCase.mockSuccess(
       response = Result.success(WatchlistResponseFactory.emptyMovies()),
@@ -204,8 +200,6 @@ class WatchlistScreenTest : ComposeTest() {
 
   @Test
   fun `test watchlist with movies and tv content`() {
-    val destinationsNavigator = FakeDestinationsNavigator()
-
     observeAccountUseCase.mockSuccess(response = Result.success(true))
     fetchWatchlistUseCase.mockSuccess(
       response = flowOf(
@@ -245,6 +239,14 @@ class WatchlistScreenTest : ComposeTest() {
       )
 
     composeTestRule.onNodeWithText(movieList.last().name).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(TestTags.SCROLL_TO_TOP_BUTTON).assertIsNotDisplayed()
+
+    // Scroll up to display the ScrollToTopButton
+    composeTestRule.onNodeWithTag(TestTags.Watchlist.WATCHLIST_CONTENT)
+      .performScrollToNode(
+        matcher = hasText(text = movieList[movieList.lastIndex - 1].name),
+      )
+
     composeTestRule.onNodeWithTag(TestTags.SCROLL_TO_TOP_BUTTON).assertIsDisplayed().performClick()
 
     // Should be at the top of the list


### PR DESCRIPTION
This pull request updates the UI and visibility logic of the `scroll to top` button in existing locations while introducing it on the Person Screen. 

The button previously appeared after scrolling through 6 items; now, it shows up after scrolling past 3 items, including backward navigation. This adjustment ensures the button only appears once we detect the user's intent to scroll upward.

### Screen recording

https://github.com/user-attachments/assets/526a8448-c57b-4ab8-a2c6-50a0df439221
