### PR TITLE
Update popular and recommendations API query parameters

### DIFF
--- a/core/domain/src/test/kotlin/com/divinelink/core/domain/session/CreateSessionUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/divinelink/core/domain/session/CreateSessionUseCaseTest.kt
@@ -1,6 +1,7 @@
 package com.divinelink.core.domain.session
 
 import com.divinelink.core.datastore.SessionStorage
+import com.divinelink.core.fixtures.model.account.AccountDetailsFactory
 import com.divinelink.core.model.session.Session
 import com.divinelink.core.testing.MainDispatcherRule
 import com.divinelink.core.testing.repository.TestSessionRepository
@@ -8,6 +9,7 @@ import com.divinelink.core.testing.storage.FakeAccountStorage
 import com.divinelink.core.testing.storage.FakeEncryptedPreferenceStorage
 import com.divinelink.core.testing.storage.FakePreferenceStorage
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import kotlin.test.Test
@@ -45,6 +47,40 @@ class CreateSessionUseCaseTest {
   }
 
   @Test
+  fun `test on create session with success session and account details stores them`() = runTest {
+    val repository = TestSessionRepository()
+    val storage = SessionStorage(
+      storage = FakePreferenceStorage(),
+      encryptedStorage = FakeEncryptedPreferenceStorage(),
+      accountStorage = FakeAccountStorage(),
+    )
+
+    repository.mockCreateSession(
+      response = Result.success(Session(id = "sessionId")),
+    )
+
+    repository.mockGetAccountDetails(
+      response = Result.success(AccountDetailsFactory.Pinkman()),
+    )
+
+    val useCase = CreateSessionUseCase(
+      repository = repository.mock,
+      storage = storage,
+      dispatcher = testDispatcher,
+    )
+
+    assertThat(storage.sessionId).isNull()
+
+    useCase("requestToken")
+
+    assertThat(storage.sessionId).isEqualTo("sessionId")
+
+    assertThat(
+      storage.accountStorage.accountDetails.first(),
+    ).isEqualTo(AccountDetailsFactory.Pinkman())
+  }
+
+  @Test
   fun `test on create session with failure does not save session to storage`() = runTest {
     val repository = TestSessionRepository()
     val storage = SessionStorage(
@@ -68,5 +104,40 @@ class CreateSessionUseCaseTest {
     useCase("requestToken")
 
     assertThat(storage.sessionId).isNull()
+  }
+
+  @Test
+  fun `test on create session with failure clears session storage`() = runTest {
+    val repository = TestSessionRepository()
+    val storage = SessionStorage(
+      storage = FakePreferenceStorage(),
+      encryptedStorage = FakeEncryptedPreferenceStorage(),
+      accountStorage = FakeAccountStorage(),
+    )
+
+    storage.setTMDbAccountDetails(AccountDetailsFactory.Pinkman())
+    storage.setSession("sessionId")
+
+    repository.mockCreateSession(
+      response = Result.failure(Exception()),
+    )
+
+    val useCase = CreateSessionUseCase(
+      repository = repository.mock,
+      storage = storage,
+      dispatcher = testDispatcher,
+    )
+
+    assertThat(storage.sessionId).isEqualTo("sessionId")
+    assertThat(
+      storage.accountStorage.accountDetails.first(),
+    ).isEqualTo(AccountDetailsFactory.Pinkman())
+
+    useCase("requestToken")
+
+    assertThat(storage.sessionId).isNull()
+    assertThat(
+      storage.accountStorage.accountDetails.first(),
+    ).isNull()
   }
 }

--- a/core/network/src/main/kotlin/com/divinelink/core/network/media/service/ProdMediaService.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/media/service/ProdMediaService.kt
@@ -95,8 +95,9 @@ class ProdMediaService(private val restClient: TMDbClient) : MediaService {
     val baseUrl = "${restClient.tmdbUrl}/${request.endpoint}/"
     val url = baseUrl +
       "${request.id}" +
-      "/similar?" +
-      "&language=en-US"
+      "/recommendations?" +
+      "&language=en-US" +
+      "&include_adult=false"
 
     val response = restClient.get<SimilarResponseApi>(url = url)
 

--- a/core/network/src/main/kotlin/com/divinelink/core/network/media/service/ProdMediaService.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/media/service/ProdMediaService.kt
@@ -31,8 +31,13 @@ import kotlinx.coroutines.flow.flow
 class ProdMediaService(private val restClient: TMDbClient) : MediaService {
 
   override fun fetchPopularMovies(request: MoviesRequestApi): Flow<MoviesResponseApi> = flow {
-    val baseUrl = "${restClient.tmdbUrl}/movie/popular?"
-    val url = baseUrl + "&language=en-US&page=${request.page}"
+    val baseUrl = "${restClient.tmdbUrl}/discover/movie?"
+    val url = baseUrl +
+      "&include_adult=false" +
+      "&language=en-US" +
+      "&page=${request.page}" +
+      "&sort_by=popularity.desc" +
+      "&vote_count.gte=50"
 
     val response = restClient.get<MoviesResponseApi>(url = url)
 

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
 
   <string name="core_ui_review_author">A review by: %s, %s</string>
   <string name="details__reviews">Reviews</string>
-  <string name="details__more_like_this">More like this</string>
+  <string name="details__more_like_this">Recommendations</string>
 
   <string name="details__director_title">Director</string>
   <string name="details__cast_title">Cast</string>


### PR DESCRIPTION
Lately, TMDB used to return irrelevant data for popular movies. Upon the [API](https://developer.themoviedb.org/reference/movie-popular-list) inspection - which underlines that the `popular` api call is just a  _discover call behind the scenes_ - we tweaked the default filter parameters in order fetch more relevant movies.

Additionally, we updated the [similar](https://developer.themoviedb.org/reference/movie-similar) to [recommendations](https://developer.themoviedb.org/reference/movie-recommendations) API to also fetch more relevant recommended movies. 