### PR TITLE
Fix login issue on release variants due to missing proguard rules

### DIFF
--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
   alias(libs.plugins.divinelink.android.koin)
 }
 
+android {
+  defaultConfig {
+    consumerProguardFiles("consumer-proguard-rules.pro")
+  }
+}
+
 dependencies {
   implementation(libs.datastore)
   implementation(libs.datastore.core)
@@ -18,6 +24,5 @@ dependencies {
 
   implementation(libs.timber)
 
-//  testImplementation(projects.core.datastoreTest)
   testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/core/datastore/consumer-proguard-rules.pro
+++ b/core/datastore/consumer-proguard-rules.pro
@@ -1,0 +1,4 @@
+# Keep DataStore fields
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite* {
+   <fields>;
+}


### PR DESCRIPTION
This pull request fixes login issues due to proto datastore being minified on release variants. We fix that by adding a proguard rule that keeps the proto files when using R8.