### PR TITLE
[Onboarding] Add open external url page on onboarding

### DIFF
--- a/core/commons/src/main/kotlin/com/divinelink/core/commons/util/AppSettingsUtil.kt
+++ b/core/commons/src/main/kotlin/com/divinelink/core/commons/util/AppSettingsUtil.kt
@@ -3,6 +3,7 @@ package com.divinelink.core.commons.util
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.provider.Settings
 import androidx.core.content.ContextCompat.startActivity
 
@@ -10,7 +11,13 @@ object AppSettingsUtil {
   private const val PACKAGE_SCHEME = "package"
 
   fun openAppDetails(context: Context) {
-    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+    val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      Intent(Settings.ACTION_APP_OPEN_BY_DEFAULT_SETTINGS)
+    } else {
+      Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+    }
+
+    intent.apply {
       data = Uri.fromParts(PACKAGE_SCHEME, context.packageName, null)
     }
     startActivity(context, intent, null)

--- a/core/model/src/main/kotlin/com/divinelink/core/model/onboarding/OnboardingAction.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/onboarding/OnboardingAction.kt
@@ -5,7 +5,7 @@ import com.divinelink.core.model.UIText
 
 sealed class OnboardingAction(
   val actionText: UIText,
-  val completedActionText: UIText,
+  val completedActionText: UIText? = null,
   open val isComplete: Boolean = false,
 ) {
   data class NavigateToTMDBLogin(override val isComplete: Boolean) :
@@ -24,4 +24,8 @@ sealed class OnboardingAction(
         R.string.core_model_onboarding_successfully_connected,
       ),
     )
+
+  data object NavigateToLinkHandling : OnboardingAction(
+    actionText = UIText.ResourceText(R.string.core_model_onboarding_link_handling_action),
+  )
 }

--- a/core/model/src/main/res/values/strings.xml
+++ b/core/model/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
   <string name="core_model_tv_status_continuing">Continuing</string>
   <string name="core_model_tv_status_unknown">Unknown</string>
 
+  <string name="core_model_onboarding_link_handling_action">Open settings</string>
   <string name="core_model_onboarding_tmdb_page_action">Connect TMDB Account</string>
   <string name="core_model_onboarding_jellyseerr_page_action">Link Jellyseerr Account</string>
 

--- a/feature/onboarding/src/main/kotlin/com/divinelink/feature/onboarding/manager/OnboardingPages.kt
+++ b/feature/onboarding/src/main/kotlin/com/divinelink/feature/onboarding/manager/OnboardingPages.kt
@@ -12,7 +12,7 @@ object OnboardingPages {
     title = UIText.ResourceText(R.string.feature_onboarding_jellyseerr_page_title),
     description = UIText.ResourceText(R.string.feature_onboarding_jellyseerr_page_description),
     image = com.divinelink.core.ui.R.drawable.core_ui_ic_jellyseerr,
-    showSkipButton = false,
+    showSkipButton = true,
     action = OnboardingAction.NavigateToJellyseerrLogin(isComplete = false),
   )
 
@@ -25,6 +25,15 @@ object OnboardingPages {
     action = OnboardingAction.NavigateToTMDBLogin(isComplete = false),
   )
 
+  val linkHandlingPage = OnboardingPage(
+    tag = "link_handling",
+    title = UIText.ResourceText(R.string.feature_onboarding_link_handling_page_title),
+    description = UIText.ResourceText(R.string.feature_onboarding_link_handling_page_description),
+    image = null,
+    showSkipButton = false,
+    action = OnboardingAction.NavigateToLinkHandling,
+  )
+
   val initialPages = listOf(
     OnboardingPage(
       tag = "welcome",
@@ -35,6 +44,7 @@ object OnboardingPages {
     ),
     tmdbPage,
     jellyseerrPage,
+    linkHandlingPage,
   )
 
   val newFeaturePages = emptyMap<Int, List<OnboardingPage>>()

--- a/feature/onboarding/src/main/kotlin/com/divinelink/feature/onboarding/ui/OnboardingItem.kt
+++ b/feature/onboarding/src/main/kotlin/com/divinelink/feature/onboarding/ui/OnboardingItem.kt
@@ -21,6 +21,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.divinelink.core.designsystem.theme.AppTheme
@@ -75,7 +77,7 @@ fun OnboardingItem(
         .fillMaxWidth()
         .padding(horizontal = MaterialTheme.dimensions.keyline_24),
       textAlign = TextAlign.Center,
-      text = page.description.getString(),
+      text = AnnotatedString.fromHtml(page.description.getString()),
       style = MaterialTheme.typography.bodyLarge,
     )
 
@@ -96,7 +98,7 @@ fun OnboardingItem(
 
       page.action?.let { action ->
         if (action.isComplete) {
-          SuccessText(action.completedActionText)
+          action.completedActionText?.let { SuccessText(it) }
         } else {
           Button(
             modifier = Modifier.fillMaxWidth(),

--- a/feature/onboarding/src/main/kotlin/com/divinelink/feature/onboarding/ui/OnboardingScreen.kt
+++ b/feature/onboarding/src/main/kotlin/com/divinelink/feature/onboarding/ui/OnboardingScreen.kt
@@ -8,8 +8,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.divinelink.core.commons.util.AppSettingsUtil
 import com.divinelink.core.model.onboarding.OnboardingAction
 import com.divinelink.core.ui.TestTags
 import org.koin.androidx.compose.koinViewModel
@@ -22,6 +24,7 @@ fun OnboardingScreen(
   viewModel: OnboardingViewModel = koinViewModel(),
 ) {
   val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+  val context = LocalContext.current
 
   LaunchedEffect(Unit) {
     viewModel.onNavigateUp.collect {
@@ -50,6 +53,7 @@ fun OnboardingScreen(
           when (action) {
             is OnboardingAction.NavigateToJellyseerrLogin -> onNavigateToJellyseerrSettings()
             is OnboardingAction.NavigateToTMDBLogin -> onNavigateToTMDBLogin()
+            is OnboardingAction.NavigateToLinkHandling -> AppSettingsUtil.openAppDetails(context)
           }
         },
       )

--- a/feature/onboarding/src/main/res/values/strings.xml
+++ b/feature/onboarding/src/main/res/values/strings.xml
@@ -11,4 +11,18 @@
 
   <string name="feature_onboarding_jellyseerr_page_title">Jellyseerr Integration</string>
   <string name="feature_onboarding_jellyseerr_page_description">If you have access to a Jellyseerr server, connect your account to request movies and TV shows instantly.</string>
+
+  <string name="feature_onboarding_link_handling_page_title">IMDb &amp; TMDB Link Handling</string>
+  <string name="feature_onboarding_link_handling_page_description">
+    <![CDATA[
+    ScenePeek can open <strong>URLs</strong> from <strong>IMDb</strong> &amp; <strong>TMDB</strong> in the app. This can be useful for opening links to movies, TV shows and person directly in the app.
+    <br><br>
+    To enable this, follow these steps:<br>
+    1. Open the settings by pressing the button below.<br>
+    2. <strong>Open by default</strong> or <strong>Set as default section</strong>.<br>
+    3. Choose <strong>Open supported links</strong> for ScenePeek<br>
+    <br><br>
+    (some devices have this listed under <strong>Default Apps</strong> in the main settings followed by selecting ScenePeek for relevant categories)
+    ]]>
+  </string>
 </resources>

--- a/feature/onboarding/src/test/kotlin/com/divinelink/feature/onboarding/OnboardingViewModelTest.kt
+++ b/feature/onboarding/src/test/kotlin/com/divinelink/feature/onboarding/OnboardingViewModelTest.kt
@@ -9,6 +9,7 @@ import com.divinelink.core.testing.MainDispatcherRule
 import com.divinelink.core.testing.assertUiState
 import com.divinelink.feature.onboarding.manager.OnboardingPages
 import com.divinelink.feature.onboarding.manager.OnboardingPages.jellyseerrPage
+import com.divinelink.feature.onboarding.manager.OnboardingPages.linkHandlingPage
 import com.divinelink.feature.onboarding.manager.OnboardingPages.tmdbPage
 import com.divinelink.feature.onboarding.ui.OnboardingUiState
 import kotlinx.coroutines.test.runTest
@@ -137,6 +138,7 @@ class OnboardingViewModelTest {
             ),
             tmdbPage.copy(action = OnboardingAction.NavigateToTMDBLogin(isComplete = true)),
             jellyseerrPage,
+            linkHandlingPage,
           ),
           startedJobs = listOf("tmdb"),
         ),
@@ -168,6 +170,7 @@ class OnboardingViewModelTest {
             jellyseerrPage.copy(
               action = OnboardingAction.NavigateToJellyseerrLogin(isComplete = true),
             ),
+            linkHandlingPage,
           ),
           startedJobs = listOf("jellyseerr"),
         ),


### PR DESCRIPTION
This pull request adds a new page on the initial onboarding pages, in order to inform the user that they can open `IMDb` and `TMDB` links on the app. 

It also updates the action button to automatically open the correct settings, on the devices with sdk version greater than 31. 