### PR TITLE
[Auth] Open TMDB screen directly from non settings entry points

### DIFF
--- a/app/src/main/kotlin/com/divinelink/scenepeek/navigation/ScenePeekNavHost.kt
+++ b/app/src/main/kotlin/com/divinelink/scenepeek/navigation/ScenePeekNavHost.kt
@@ -107,7 +107,7 @@ fun ScenePeekNavHost(state: ScenePeekAppState) {
         onNavigateToDetails = navController::navigateToDetails,
         onNavigateToCredits = navController::navigateToCredits,
         onNavigateToPerson = navController::navigateToPerson,
-        onNavigateToAccountSettings = navController::navigateToAccountSettings,
+        onNavigateToTMDBLogin = navController::navigateToTMDBAuth,
       )
 
       creditsScreen(
@@ -116,8 +116,8 @@ fun ScenePeekNavHost(state: ScenePeekAppState) {
       )
 
       watchlistScreen(
-        onNavigateToAccountSettings = navController::navigateToAccountSettings,
         onNavigateToDetails = navController::navigateToDetails,
+        onNavigateToTMDBLogin = navController::navigateToTMDBAuth,
       )
 
       onboardingScreen(

--- a/app/src/test/kotlin/com/divinelink/ui/details/DetailsScreenTest.kt
+++ b/app/src/test/kotlin/com/divinelink/ui/details/DetailsScreenTest.kt
@@ -85,7 +85,7 @@ class DetailsScreenTest : ComposeTest() {
 
     setContentWithTheme {
       DetailsScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToCredits = {},
         viewModel = DetailsViewModel(
           getMediaDetailsUseCase = getMovieDetailsUseCase.mock,
@@ -179,7 +179,7 @@ class DetailsScreenTest : ComposeTest() {
 
     setContentWithTheme {
       DetailsScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToCredits = {},
         viewModel = viewModel,
         onNavigateUp = {},
@@ -239,7 +239,7 @@ class DetailsScreenTest : ComposeTest() {
 
     setContentWithTheme {
       DetailsScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToCredits = {},
         viewModel = viewModel,
         onNavigateUp = {},
@@ -305,7 +305,7 @@ class DetailsScreenTest : ComposeTest() {
 
     setContentWithTheme {
       DetailsScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToCredits = {
           route = it
           navigatedToCredits = true
@@ -370,7 +370,7 @@ class DetailsScreenTest : ComposeTest() {
 
     setContentWithTheme {
       DetailsScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToCredits = {},
         viewModel = DetailsViewModel(
           getMediaDetailsUseCase = getMovieDetailsUseCase.mock,
@@ -437,7 +437,7 @@ class DetailsScreenTest : ComposeTest() {
 
     setContentWithTheme {
       DetailsScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToCredits = {},
         viewModel = viewModel,
         onNavigateUp = {},
@@ -497,7 +497,7 @@ class DetailsScreenTest : ComposeTest() {
         onNavigateUp = {},
         onNavigateToDetails = {},
         onNavigateToPerson = {},
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToCredits = {},
         viewModel = viewModel,
       )

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
@@ -32,7 +32,7 @@ fun DetailsScreen(
   onNavigateToDetails: (DetailsRoute) -> Unit,
   onNavigateToCredits: (CreditsRoute) -> Unit,
   onNavigateToPerson: (PersonRoute) -> Unit,
-  onNavigateToAccountSettings: () -> Unit,
+  onNavigateToTMDBLogin: () -> Unit,
   viewModel: DetailsViewModel = koinViewModel(),
 ) {
   val viewState = viewModel.viewState.collectAsState()
@@ -42,7 +42,7 @@ fun DetailsScreen(
 
   LaunchedEffect(viewState.value.navigateToLogin) {
     viewState.value.navigateToLogin?.let {
-      onNavigateToAccountSettings()
+      onNavigateToTMDBLogin()
 
       viewModel.consumeNavigateToLogin()
     }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/navigation/DetailsNavigation.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/navigation/DetailsNavigation.kt
@@ -15,7 +15,7 @@ fun NavGraphBuilder.detailsScreen(
   onNavigateToDetails: (DetailsRoute) -> Unit,
   onNavigateToCredits: (CreditsRoute) -> Unit,
   onNavigateToPerson: (PersonRoute) -> Unit,
-  onNavigateToAccountSettings: () -> Unit,
+  onNavigateToTMDBLogin: () -> Unit,
 ) {
   composable<DetailsRoute> {
     DetailsScreen(
@@ -23,7 +23,7 @@ fun NavGraphBuilder.detailsScreen(
       onNavigateToDetails = onNavigateToDetails,
       onNavigateToCredits = onNavigateToCredits,
       onNavigateToPerson = onNavigateToPerson,
-      onNavigateToAccountSettings = onNavigateToAccountSettings,
+      onNavigateToTMDBLogin = onNavigateToTMDBLogin,
     )
   }
 }

--- a/feature/watchlist/src/main/kotlin/com/divinelink/feature/watchlist/WatchlistScreen.kt
+++ b/feature/watchlist/src/main/kotlin/com/divinelink/feature/watchlist/WatchlistScreen.kt
@@ -36,7 +36,7 @@ import org.koin.androidx.compose.koinViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun WatchlistScreen(
-  onNavigateToAccountSettings: () -> Unit,
+  onNavigateToTMDBLogin: () -> Unit,
   onNavigateToMediaDetails: (DetailsRoute) -> Unit,
   viewModel: WatchlistViewModel = koinViewModel(),
 ) {
@@ -90,7 +90,7 @@ fun WatchlistScreen(
             )
             is WatchlistForm.Error -> WatchlistErrorContent(
               error = it,
-              onLogin = onNavigateToAccountSettings,
+              onLogin = onNavigateToTMDBLogin,
               onRetry = {
               },
             )

--- a/feature/watchlist/src/main/kotlin/com/divinelink/feature/watchlist/navigation/WatchlistNavigation.kt
+++ b/feature/watchlist/src/main/kotlin/com/divinelink/feature/watchlist/navigation/WatchlistNavigation.kt
@@ -18,12 +18,12 @@ fun NavController.navigateToWatchlist(navOptions: NavOptions) = navigate(
 
 fun NavGraphBuilder.watchlistScreen(
   onNavigateToDetails: (DetailsRoute) -> Unit,
-  onNavigateToAccountSettings: () -> Unit,
+  onNavigateToTMDBLogin: () -> Unit,
 ) {
   composable<WatchlistRoute> {
     WatchlistScreen(
       onNavigateToMediaDetails = onNavigateToDetails,
-      onNavigateToAccountSettings = onNavigateToAccountSettings,
+      onNavigateToTMDBLogin = onNavigateToTMDBLogin,
     )
   }
 }

--- a/feature/watchlist/src/test/kotlin/com/divinelink/feature/watchlist/WatchlistScreenTest.kt
+++ b/feature/watchlist/src/test/kotlin/com/divinelink/feature/watchlist/WatchlistScreenTest.kt
@@ -34,7 +34,7 @@ class WatchlistScreenTest : ComposeTest() {
 
     setContentWithTheme {
       WatchlistScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToMediaDetails = {},
         viewModel = WatchlistViewModel(
           observeAccountUseCase = observeAccountUseCase.mock,
@@ -53,14 +53,14 @@ class WatchlistScreenTest : ComposeTest() {
 
   @Test
   fun `test unauthenticated error`() {
-    var verifyNavigatedToAccountSettings = false
+    var verifyNavigatedToTMDBLogin = false
 
     observeAccountUseCase.mockSuccess(response = Result.failure(SessionException.Unauthenticated()))
 
     setContentWithTheme {
       WatchlistScreen(
-        onNavigateToAccountSettings = {
-          verifyNavigatedToAccountSettings = true
+        onNavigateToTMDBLogin = {
+          verifyNavigatedToTMDBLogin = true
         },
         onNavigateToMediaDetails = {},
         viewModel = WatchlistViewModel(
@@ -84,7 +84,7 @@ class WatchlistScreenTest : ComposeTest() {
 
     // Navigate to Login
     composeTestRule.onNodeWithText(loginButton).performClick()
-    assertThat(verifyNavigatedToAccountSettings).isTrue()
+    assertThat(verifyNavigatedToTMDBLogin).isTrue()
   }
 
   @Test
@@ -93,7 +93,7 @@ class WatchlistScreenTest : ComposeTest() {
 
     setContentWithTheme {
       WatchlistScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToMediaDetails = {},
         viewModel = WatchlistViewModel(
           observeAccountUseCase = observeAccountUseCase.mock,
@@ -127,7 +127,7 @@ class WatchlistScreenTest : ComposeTest() {
 
     setContentWithTheme {
       WatchlistScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToMediaDetails = {},
         viewModel = WatchlistViewModel(
           observeAccountUseCase = observeAccountUseCase.mock,
@@ -169,7 +169,7 @@ class WatchlistScreenTest : ComposeTest() {
 
     setContentWithTheme {
       WatchlistScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToMediaDetails = {},
         viewModel = WatchlistViewModel(
           observeAccountUseCase = observeAccountUseCase.mock,
@@ -210,7 +210,7 @@ class WatchlistScreenTest : ComposeTest() {
 
     setContentWithTheme {
       WatchlistScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToMediaDetails = {},
         viewModel = WatchlistViewModel(
           observeAccountUseCase = observeAccountUseCase.mock,
@@ -269,7 +269,7 @@ class WatchlistScreenTest : ComposeTest() {
 
     setContentWithTheme {
       WatchlistScreen(
-        onNavigateToAccountSettings = {},
+        onNavigateToTMDBLogin = {},
         onNavigateToMediaDetails = {
           verifyNavigatedToMediaDetails = true
           navArgs = it


### PR DESCRIPTION
This pull request enhances the login process by directly opening the TMDB auth screen when the user is prompted to login on details and watchlist screen. 

This have been easily achieved due to #96.