### PR TITLE
Update kotlin and various libraries 

### DIFF
--- a/core/datastore/src/main/java/com/divinelink/core/datastore/account/AccountDetailsSerializer.kt
+++ b/core/datastore/src/main/java/com/divinelink/core/datastore/account/AccountDetailsSerializer.kt
@@ -2,8 +2,8 @@ package com.divinelink.core.datastore.account
 
 import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.Serializer
-import androidx.datastore.preferences.protobuf.InvalidProtocolBufferException
 import com.divinelink.core.datastore.AccountDetailsProto
+import com.google.protobuf.InvalidProtocolBufferException
 import java.io.InputStream
 import java.io.OutputStream
 

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/ModifierExtensions.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/ModifierExtensions.kt
@@ -1,18 +1,9 @@
 package com.divinelink.core.ui
 
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.AutofillNode
-import androidx.compose.ui.autofill.AutofillType
-import androidx.compose.ui.composed
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.BlurEffect
 import androidx.compose.ui.graphics.TileMode
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.boundsInWindow
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalAutofill
-import androidx.compose.ui.platform.LocalAutofillTree
 
 /**
  * Conditionally applies the given [Modifier]s based on the given [condition].
@@ -35,7 +26,7 @@ fun Modifier.blurEffect(
   radiusX: Float = 15f,
   radiusY: Float = 15f,
 ): Modifier = this.then(
-  graphicsLayer {
+  Modifier.graphicsLayer {
     renderEffect = BlurEffect(
       radiusX = radiusX,
       radiusY = radiusY,
@@ -43,27 +34,3 @@ fun Modifier.blurEffect(
     )
   },
 )
-
-@OptIn(ExperimentalComposeUiApi::class)
-fun Modifier.autofill(
-  autofillTypes: List<AutofillType>,
-  onFill: ((String) -> Unit),
-) = composed {
-  val autofill = LocalAutofill.current
-  val autofillNode = AutofillNode(onFill = onFill, autofillTypes = autofillTypes)
-  LocalAutofillTree.current += autofillNode
-
-  this
-    .onGloballyPositioned {
-      autofillNode.boundingBox = it.boundsInWindow()
-    }
-    .onFocusChanged { focusState ->
-      autofill?.run {
-        if (focusState.isFocused) {
-          requestAutofillForNode(autofillNode)
-        } else {
-          cancelAutofillForNode(autofillNode)
-        }
-      }
-    }
-}

--- a/feature/details/src/test/kotlin/com/divinelink/feature/details/person/ui/PersonScreenTest.kt
+++ b/feature/details/src/test/kotlin/com/divinelink/feature/details/person/ui/PersonScreenTest.kt
@@ -906,8 +906,11 @@ class PersonScreenTest : ComposeTest() {
       onNodeWithText("Movies").performClick()
 
       // Apply filter to Movies tab
+      onNodeWithTag(TestTags.Person.CREDITS_FILTER_BOTTOM_SHEET).assertIsNotDisplayed()
       onNodeWithTag(TestTags.Components.FILTER_BUTTON).performClick()
+      onNodeWithTag(TestTags.Person.CREDITS_FILTER_BOTTOM_SHEET).assertIsDisplayed()
       onNodeWithText("Writing (1)").performClick()
+      onNodeWithTag(TestTags.Person.CREDITS_FILTER_BOTTOM_SHEET).assertIsNotDisplayed()
 
       // Switch to TV Shows tab
       onNodeWithText("TV Shows").performClick()

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrInitialContent.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrInitialContent.kt
@@ -33,11 +33,13 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.autofill.AutofillType
+import androidx.compose.ui.autofill.ContentType
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentType
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.designsystem.theme.dimensions
@@ -46,7 +48,6 @@ import com.divinelink.core.model.jellyseerr.JellyseerrState
 import com.divinelink.core.ui.PasswordOutlinedTextField
 import com.divinelink.core.ui.Previews
 import com.divinelink.core.ui.TestTags
-import com.divinelink.core.ui.autofill
 import com.divinelink.feature.settings.R
 import com.divinelink.core.ui.R as uiR
 
@@ -98,10 +99,9 @@ fun JellyseerrInitialContent(
       content = {
         OutlinedTextField(
           modifier = Modifier
-            .autofill(
-              autofillTypes = listOf(AutofillType.Username),
-              onFill = { interaction(JellyseerrInteraction.OnUsernameChange(it)) },
-            )
+            .semantics {
+              contentType = ContentType.Username
+            }
             .testTag(TestTags.Settings.Jellyseerr.JELLYFIN_USERNAME_TEXT_FIELD)
             .fillMaxWidth(),
           value = jellyseerrState.jellyfinLogin.username.value,
@@ -112,10 +112,9 @@ fun JellyseerrInitialContent(
 
         PasswordOutlinedTextField(
           modifier = Modifier
-            .autofill(
-              autofillTypes = listOf(AutofillType.Password),
-              onFill = { interaction(JellyseerrInteraction.OnPasswordChange(it)) },
-            )
+            .semantics {
+              contentType = ContentType.Password
+            }
             .testTag(TestTags.Settings.Jellyseerr.JELLYFIN_PASSWORD_TEXT_FIELD)
             .fillMaxWidth(),
           value = jellyseerrState.jellyfinLogin.password.value,
@@ -139,10 +138,9 @@ fun JellyseerrInitialContent(
       content = {
         OutlinedTextField(
           modifier = Modifier
-            .autofill(
-              autofillTypes = listOf(AutofillType.EmailAddress),
-              onFill = { interaction(JellyseerrInteraction.OnUsernameChange(it)) },
-            )
+            .semantics {
+              contentType = ContentType.EmailAddress
+            }
             .testTag(TestTags.Settings.Jellyseerr.JELLYSEERR_USERNAME_TEXT_FIELD)
             .fillMaxWidth(),
           value = jellyseerrState.jellyseerrLogin.username.value,
@@ -153,10 +151,9 @@ fun JellyseerrInitialContent(
 
         PasswordOutlinedTextField(
           modifier = Modifier
-            .autofill(
-              autofillTypes = listOf(AutofillType.Password),
-              onFill = { interaction(JellyseerrInteraction.OnPasswordChange(it)) },
-            )
+            .semantics {
+              contentType = ContentType.Password
+            }
             .testTag(TestTags.Settings.Jellyseerr.JELLYSEERR_PASSWORD_TEXT_FIELD)
             .fillMaxWidth(),
           value = jellyseerrState.jellyseerrLogin.password.value,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,26 +5,26 @@ version-code = "18"
 firebase-appdistribution-gradle = "5.0.0"
 firebase-crashlytics-gradle = "3.0.2"
 google-services = "4.4.2"
-kotlin = "2.0.20"
+kotlin = "2.1.0"
 ksp = "2.0.20-1.0.24"
 android-tools = "31.7.2"
 # android-tools and agp should be updated together
 agp = "8.7.2"
-core-ktx = "1.13.1"
+core-ktx = "1.15.0"
 coil = "3.0.4"
 junit = "4.13.2"
 androidx-test-ext-junit = "1.2.1"
-androidx-tracing = "1.3.0-alpha02"
+androidx-tracing = "1.3.0-beta01"
 androidx-browser = "1.8.0"
-lifecycle-runtime-ktx = "2.8.6"
-activity-compose = "1.9.2"
+lifecycle-runtime-ktx = "2.8.7"
+activity-compose = "1.10.1"
 start-up = "1.2.0"
 kotlinx-datetime = "0.6.0"
 ktlint = "12.1.1"
 secrets = "2.0.1"
 desugar = "2.0.4"
-navigation-runtime-ktx = "2.8.6"
-navigation-compose = "2.8.6"
+navigation-runtime-ktx = "2.8.9"
+navigation-compose = "2.8.9"
 protobuf = "4.26.1"
 protobufPlugin = "0.9.4"
 
@@ -33,7 +33,7 @@ detekt = "1.23.6"
 # Internal Database
 room = "2.6.1"
 sqldelight = "2.0.2"
-datastore = '1.1.1'
+datastore = '1.1.4'
 encrypted-prefs = '1.1.0-alpha04'
 
 # Multithreading
@@ -47,7 +47,8 @@ kotlinx-serialization = "1.7.1"
 koin = "4.0.0"
 
 # Compose
-compose-bom = "2025.01.01"
+compose-bom = "2025.03.01"
+# 1.8.0-rc2 creates compose test issues with bottom sheets on person screen
 compose-foundation = "1.8.0-alpha08"
 material3 = "1.3.1"
 
@@ -58,14 +59,14 @@ timber = "5.0.1"
 
 # Testing
 kover = "0.8.3"
-screenshot = "0.0.1-alpha08"
+screenshot = "0.0.1-alpha09"
 androidx-test = "1.6.1"
 truth = "1.4.2"
 turbine = "1.1.0"
 
 # UI
 robolectric = "4.12.2"
-androidx-compose-ui-test = "1.7.3"
+androidx-compose-ui-test = "1.7.8"
 ui-automator = "2.3.0"
 
 # Mockers


### PR DESCRIPTION
This pull request updates kotlin to 2.1.0 as well as some other libraries. 

### Changes

* Update deprecated `autofill` modifier with semantics `ContentType` that is needed for password managers.