### PR TITLE
Fix episode count on old android versions

### DIFF
--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/Previews.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/Previews.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.tooling.preview.Preview
 @Preview(name = "light mode", uiMode = Configuration.UI_MODE_NIGHT_NO)
 @Preview(name = "dark mode", uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Preview(name = "accessibility", device = "spec:width=360dp,height=640dp,dpi=480", fontScale = 2.0f)
+@Preview(name = "api 30", uiMode = Configuration.UI_MODE_NIGHT_NO, apiLevel = 30)
 annotation class Previews
 
 @Retention(AnnotationRetention.RUNTIME)

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/cast/CreditsItemCard.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/details/cast/CreditsItemCard.kt
@@ -1,5 +1,6 @@
 package com.divinelink.core.ui.components.details.cast
 
+import android.os.Build
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -100,7 +101,11 @@ fun CreditsItemCard(
                   condition = obfuscateEpisodes,
                   ifTrue = { blurEffect() },
                 ),
-              text = stringResource(R.string.core_ui_episode_count, episodes),
+              text = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S && obfuscateEpisodes) {
+                ""
+              } else {
+                stringResource(R.string.core_ui_episode_count, episodes)
+              },
               maxLines = 1,
               style = MaterialTheme.typography.bodySmall,
               overflow = TextOverflow.Ellipsis,

--- a/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/PersonItem.kt
+++ b/feature/credits/src/main/kotlin/com/divinelink/feature/credits/ui/PersonItem.kt
@@ -1,5 +1,6 @@
 package com.divinelink.feature.credits.ui
 
+import android.os.Build
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -153,16 +154,21 @@ fun CharacterWithBlurredEpisodes(
     style = baseStyle,
   )
 
-  Text(
-    text = " ",
-    style = baseStyle,
-  )
-
-  Text(
-    text = stringResource(
+  val episodesCount = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S && isObfuscated) {
+    ""
+  } else {
+    Text(
+      text = " ",
+      style = baseStyle,
+    )
+    stringResource(
       R.string.feature_credits_character_total_episodes,
       episodes,
-    ),
+    )
+  }
+
+  Text(
+    text = episodesCount,
     style = episodeStyle,
     modifier = Modifier.conditional(
       condition = isObfuscated,


### PR DESCRIPTION
In order to hide the episode count when the user selects to hide spoilers, we use a blur effect. However, this only works on android versions greater than 12. To fix that we added a condition on our composable to check the android version and if it's less than 12, instead of applying the modifier we completely hide the episode count.