### PR TITLE
Fix out of bounds when selecting app theme on older android devices 

### DIFF
--- a/core/designsystem/src/main/kotlin/com/divinelink/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/kotlin/com/divinelink/core/designsystem/theme/Theme.kt
@@ -1,6 +1,7 @@
 package com.divinelink.core.designsystem.theme
 
 import android.os.Build
+import androidx.annotation.StringRes
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.MaterialTheme
@@ -15,6 +16,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.unit.dp
+import com.divinelink.core.designsystem.R
 
 @Composable
 fun AppTheme(
@@ -60,10 +62,13 @@ val ListPaddingValues = PaddingValues(
   horizontal = 12.dp,
 )
 
-enum class Theme(val storageKey: String) {
-  SYSTEM("system"),
-  LIGHT("light"),
-  DARK("dark"),
+enum class Theme(
+  val storageKey: String,
+  @StringRes val label: Int,
+) {
+  SYSTEM("system", R.string.core_designsystem__system_default),
+  LIGHT("light", R.string.core_designsystem__light_theme),
+  DARK("dark", R.string.core_designsystem__dark_theme),
 }
 
 /**

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <string name="core_designsystem__light_theme">Light</string>
+  <string name="core_designsystem__dark_theme">Dark</string>
+  <string name="core_designsystem__system_default">System default</string>
+</resources>

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/appearance/AppearanceSettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/appearance/AppearanceSettingsScreen.kt
@@ -21,7 +21,6 @@ fun AppearanceSettingsScreen(
   val viewState by viewModel.uiState.collectAsState()
 
   val resources = LocalContext.current.resources
-  val themeLabels = resources.getStringArray(R.array.pref_theme_entries)
   val themeValues = resources.getStringArray(R.array.pref_theme_values)
 
   SettingsScaffold(
@@ -32,9 +31,11 @@ fun AppearanceSettingsScreen(
       item {
         SettingsRadioPrefItem(
           title = stringResource(id = R.string.preferences__theme),
-          selected = themeLabels[viewState.theme.ordinal],
+          selected = stringResource(viewState.theme.label),
           selectedIndex = themeValues.indexOf(viewState.theme.storageKey),
-          listItems = themeLabels.toList(),
+          listItems = viewState.availableThemes.map { theme ->
+            stringResource(theme.label)
+          },
           onSelected = { index ->
             viewModel.setTheme(viewState.availableThemes[index])
           },

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/appearance/usecase/GetThemeUseCase.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/appearance/usecase/GetThemeUseCase.kt
@@ -13,7 +13,6 @@ class GetThemeUseCase(
 ) : UseCase<Unit, Theme>(dispatcher.io) {
   override suspend fun execute(parameters: Unit): Theme {
     val selectedTheme = preferenceStorage.selectedTheme.first()
-    return themeFromStorageKey(selectedTheme)
-      ?: Theme.SYSTEM
+    return themeFromStorageKey(selectedTheme) ?: Theme.SYSTEM
   }
 }

--- a/feature/settings/src/main/res/values-v29/arrays.xml
+++ b/feature/settings/src/main/res/values-v29/arrays.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-  <string-array name="pref_theme_entries" tools:ignore="InconsistentArrays">
-    <item>@string/preferences__system_default</item>
-    <item>@string/preferences__light_theme</item>
-    <item>@string/preferences__dark_theme</item>
-  </string-array>
-
   <string-array name="pref_theme_values" translatable="false" tools:ignore="InconsistentArrays">
     <item>system</item>
     <item>light</item>

--- a/feature/settings/src/main/res/values/arrays.xml
+++ b/feature/settings/src/main/res/values/arrays.xml
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-  <string-array name="pref_theme_entries" tools:ignore="InconsistentArrays">
-    <item>@string/preferences__light_theme</item>
-    <item>@string/preferences__dark_theme</item>
-  </string-array>
-
   <string-array name="pref_theme_values" translatable="false" tools:ignore="InconsistentArrays">
     <item>light</item>
     <item>dark</item>
   </string-array>
-
 
 </resources>


### PR DESCRIPTION
This pull requests fixes the out of bounds issue that was present when selecting app theme on older android devices where `System default` theme is not available.