### PR TITLE
Clear back stack when navigating to search screen from home

### DIFF
--- a/core/scaffold/src/main/kotlin/com/divinelink/core/navigation/route/SearchRoute.kt
+++ b/core/scaffold/src/main/kotlin/com/divinelink/core/navigation/route/SearchRoute.kt
@@ -14,13 +14,20 @@ fun NavController.navigateToSearchFromTab(navOptions: NavOptions? = null) = navi
   route = SearchRoute,
 )
 
-fun NavController.navigateToSearchFromHome() = navigate(
-  navOptions = navOptions {
-    popUpTo(this@navigateToSearchFromHome.graph.findStartDestination().id) {
-      saveState = true
-    }
-    launchSingleTop = true
-    restoreState = true
-  },
-  route = SearchRoute,
-)
+fun NavController.navigateToSearchFromHome() {
+  navigate(
+    navOptions = navOptions {
+      popUpTo(this@navigateToSearchFromHome.graph.findStartDestination().id) {
+        saveState = true
+      }
+      launchSingleTop = true
+      restoreState = true
+    },
+    route = SearchRoute,
+  )
+
+  popBackStack(
+    route = SearchRoute,
+    inclusive = false,
+  )
+}


### PR DESCRIPTION
### Summary

We need to clear back stack when navigating to search from home search bar. 

Currently, if we were on a details screen from search, navigated to home from nav bar and then tapped on the search bar, we'd get navigated back to the details screen while we need to display search screen.