### PR TITLE
Fix clear media rating preventing ui from updating

### DIFF
--- a/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelRobot.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelRobot.kt
@@ -110,10 +110,6 @@ class DetailsViewModelRobot : ViewModelTestRobot<DetailsViewState>() {
     fakeRequestMediaUseCase.mockSuccess(response = response)
   }
 
-  fun onAddRateClicked() = apply {
-    viewModel.onAddRateClicked()
-  }
-
   fun onSubmitRate(rating: Int) = apply {
     viewModel.onSubmitRate(rating)
   }
@@ -124,10 +120,6 @@ class DetailsViewModelRobot : ViewModelTestRobot<DetailsViewState>() {
 
   fun onAddToWatchlist() = apply {
     viewModel.onAddToWatchlist()
-  }
-
-  fun onDismissRateDialog() = apply {
-    viewModel.onDismissRateDialog()
   }
 
   fun onNavigateToLogin(snackbarResult: SnackbarResult) = apply {

--- a/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelTest.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/DetailsViewModelTest.kt
@@ -682,24 +682,6 @@ class DetailsViewModelTest {
       )
       .withNavArguments(mediaId, MediaType.MOVIE)
       .buildViewModel()
-      .onAddRateClicked()
-      .assertViewState(
-        DetailsViewState(
-          mediaType = MediaType.MOVIE,
-          tabs = MovieTab.entries,
-          forms = DetailsFormFactory.Movie.loading().toMovieWzd {
-            withAbout(DetailsDataFactory.Movie.about())
-            withCast(DetailsDataFactory.Movie.cast())
-          },
-          mediaId = mediaId,
-          mediaDetails = movieDetails,
-          isLoading = false,
-          userDetails = AccountMediaDetailsFactory.NotRated().toWizard {
-            withId(mediaId)
-          },
-          showRateDialog = true,
-        ),
-      )
       .onSubmitRate(5)
       .assertViewState(
         DetailsViewState(
@@ -722,7 +704,6 @@ class DetailsViewModelTest {
             withId(mediaId)
             withRating(5.0f)
           },
-          showRateDialog = false,
         ),
       )
   }
@@ -764,7 +745,6 @@ class DetailsViewModelTest {
             actionLabelText = UIText.ResourceText(R.string.login),
             onSnackbarResult = viewModel::navigateToLogin,
           ),
-          showRateDialog = false,
         ),
       )
   }
@@ -806,7 +786,6 @@ class DetailsViewModelTest {
             actionLabelText = UIText.ResourceText(R.string.login),
             onSnackbarResult = viewModel::navigateToLogin,
           ),
-          showRateDialog = false,
         ),
       )
       .onNavigateToLogin(SnackbarResult.ActionPerformed)
@@ -889,24 +868,6 @@ class DetailsViewModelTest {
       )
       .withNavArguments(mediaId, MediaType.MOVIE)
       .buildViewModel()
-      .onAddRateClicked()
-      .assertViewState(
-        DetailsViewState(
-          mediaType = MediaType.MOVIE,
-          tabs = MovieTab.entries,
-          forms = DetailsFormFactory.Movie.loading().toMovieWzd {
-            withAbout(DetailsDataFactory.Movie.about())
-            withCast(DetailsDataFactory.Movie.cast())
-          },
-          mediaId = mediaId,
-          mediaDetails = movieDetails,
-          isLoading = false,
-          userDetails = AccountMediaDetailsFactory.NotRated().toWizard {
-            withId(mediaId)
-          },
-          showRateDialog = true,
-        ),
-      )
       .onSubmitRate(5)
       .assertViewState(
         DetailsViewState(
@@ -929,7 +890,6 @@ class DetailsViewModelTest {
             withId(mediaId)
             withRating(5.0f)
           },
-          showRateDialog = false,
         ),
       )
       .consumeSnackbar()
@@ -948,85 +908,6 @@ class DetailsViewModelTest {
             withId(mediaId)
             withRating(5.0f)
           },
-          showRateDialog = false,
-        ),
-      )
-  }
-
-  @Test
-  fun `test onAddRateClicked opens bottom sheet`() {
-    testRobot
-      .mockFetchMediaDetails(
-        response = defaultDetails(
-          MediaDetailsResult.DetailsSuccess(
-            mediaDetails = movieDetails,
-            ratingSource = RatingSource.TMDB,
-          ),
-        ),
-      )
-      .withNavArguments(mediaId, MediaType.MOVIE)
-      .buildViewModel()
-      .onAddRateClicked()
-      .assertViewState(
-        DetailsViewState(
-          mediaType = MediaType.MOVIE,
-          tabs = MovieTab.entries,
-          forms = DetailsFormFactory.Movie.loading().toMovieWzd {
-            withAbout(DetailsDataFactory.Movie.about())
-            withCast(DetailsDataFactory.Movie.cast())
-          },
-          mediaId = mediaId,
-          mediaDetails = movieDetails,
-          isLoading = false,
-          userDetails = AccountMediaDetailsFactory.NotRated(),
-          showRateDialog = true,
-        ),
-      )
-  }
-
-  @Test
-  fun `test onDismissRateDialog hides dialog`() {
-    testRobot
-      .mockFetchMediaDetails(
-        response = defaultDetails(
-          MediaDetailsResult.DetailsSuccess(
-            mediaDetails = movieDetails,
-            ratingSource = RatingSource.TMDB,
-          ),
-        ),
-      )
-      .withNavArguments(mediaId, MediaType.MOVIE)
-      .buildViewModel()
-      .onAddRateClicked()
-      .assertViewState(
-        DetailsViewState(
-          mediaType = MediaType.MOVIE,
-          tabs = MovieTab.entries,
-          forms = DetailsFormFactory.Movie.loading().toMovieWzd {
-            withAbout(DetailsDataFactory.Movie.about())
-            withCast(DetailsDataFactory.Movie.cast())
-          },
-          mediaId = mediaId,
-          mediaDetails = movieDetails,
-          isLoading = false,
-          userDetails = AccountMediaDetailsFactory.NotRated(),
-          showRateDialog = true,
-        ),
-      )
-      .onDismissRateDialog()
-      .assertViewState(
-        DetailsViewState(
-          mediaType = MediaType.MOVIE,
-          tabs = MovieTab.entries,
-          forms = DetailsFormFactory.Movie.loading().toMovieWzd {
-            withAbout(DetailsDataFactory.Movie.about())
-            withCast(DetailsDataFactory.Movie.cast())
-          },
-          mediaId = mediaId,
-          mediaDetails = movieDetails,
-          isLoading = false,
-          userDetails = AccountMediaDetailsFactory.NotRated(),
-          showRateDialog = false,
         ),
       )
   }
@@ -2805,7 +2686,7 @@ class DetailsViewModelTest {
             snackbarMessage = SnackbarMessage.from(
               text = UIText.ResourceText(
                 R.string.feature_details_jellyseerr_failure_media_delete,
-                "The Office"
+                "The Office",
               ),
             ),
           ),

--- a/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/rate/RateDialogContentTest.kt
+++ b/app/src/test/kotlin/com/divinelink/scenepeek/details/ui/rate/RateDialogContentTest.kt
@@ -4,8 +4,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import com.divinelink.core.fixtures.model.details.MediaDetailsFactory
 import com.divinelink.core.testing.ComposeTest
+import com.divinelink.core.testing.getString
 import com.divinelink.core.testing.setContentWithTheme
 import com.divinelink.feature.details.media.ui.rate.RateDialogContent
 import com.google.common.truth.Truth.assertThat
@@ -24,7 +27,6 @@ class RateDialogContentTest : ComposeTest() {
     setContentWithTheme {
       RateDialogContent(
         value = ratingValue.value,
-        onRateChanged = {},
         mediaTitle = movie.title,
         onSubmitRate = {
           submitClicked = true
@@ -34,16 +36,14 @@ class RateDialogContentTest : ComposeTest() {
       )
     }
 
-    val descriptionText = composeTestRule.activity.getString(
-      detailsR.string.details__add_rating_description,
-      movie.title,
+    val descriptionText = AnnotatedString.fromHtml(
+      getString(detailsR.string.details__add_rating_description, movie.title),
     )
 
-    val submitButtonText =
-      composeTestRule.activity.getString(detailsR.string.details__submit_rating_button)
+    val submitButtonText = getString(detailsR.string.details__submit_rating_button)
 
     with(composeTestRule) {
-      onNodeWithText(descriptionText).assertExists()
+      onNodeWithText(descriptionText.text).assertExists()
       onNodeWithText(submitButtonText).performClick()
 
       assertThat(submitClicked).isTrue()
@@ -60,26 +60,21 @@ class RateDialogContentTest : ComposeTest() {
     setContentWithTheme {
       RateDialogContent(
         value = ratingValue.value,
-        onRateChanged = {},
         mediaTitle = movie.title,
-        onSubmitRate = {
-          submitClicked = true
-        },
+        onSubmitRate = { submitClicked = true },
         onClearRate = {},
         canClearRate = true,
       )
     }
 
-    val descriptionText = composeTestRule.activity.getString(
-      detailsR.string.details__add_rating_description,
-      movie.title,
+    val descriptionText = AnnotatedString.fromHtml(
+      getString(detailsR.string.details__add_rating_description, movie.title),
     )
 
-    val submitButtonText =
-      composeTestRule.activity.getString(detailsR.string.details__submit_rating_button)
+    val submitButtonText = getString(detailsR.string.details__submit_rating_button)
 
     with(composeTestRule) {
-      onNodeWithText(descriptionText).assertExists()
+      onNodeWithText(descriptionText.text).assertExists()
       onNodeWithText(submitButtonText).assertIsNotEnabled()
       onNodeWithText(submitButtonText).performClick()
 
@@ -97,26 +92,21 @@ class RateDialogContentTest : ComposeTest() {
     setContentWithTheme {
       RateDialogContent(
         value = ratingValue.value,
-        onRateChanged = {},
         mediaTitle = movie.title,
         onSubmitRate = {},
-        onClearRate = {
-          deleteClicked = true
-        },
+        onClearRate = { deleteClicked = true },
         canClearRate = true,
       )
     }
 
-    val descriptionText = composeTestRule.activity.getString(
-      detailsR.string.details__add_rating_description,
-      movie.title,
+    val descriptionText = AnnotatedString.fromHtml(
+      getString(detailsR.string.details__add_rating_description, movie.title),
     )
 
-    val deleteButtonText =
-      composeTestRule.activity.getString(detailsR.string.details__clear_my_rating)
+    val deleteButtonText = getString(detailsR.string.details__clear_my_rating)
 
     with(composeTestRule) {
-      onNodeWithText(descriptionText).assertExists()
+      onNodeWithText(descriptionText.text).assertExists()
       onNodeWithText(deleteButtonText).performClick()
 
       assertThat(deleteClicked).isTrue()

--- a/core/network/src/main/kotlin/com/divinelink/core/network/client/KtorClient.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/client/KtorClient.kt
@@ -4,7 +4,6 @@ import com.divinelink.core.commons.Constants
 import com.divinelink.core.commons.exception.InvalidStatusException
 import com.divinelink.core.network.BuildConfig
 import io.ktor.client.HttpClient
-import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.HttpResponseValidator
 import io.ktor.client.plugins.ResponseException
@@ -110,9 +109,9 @@ suspend inline fun <reified T : Any, reified V : Any> HttpClient.delete(
 @OptIn(InternalSerializationApi::class)
 suspend inline fun <reified T : Any> HttpClient.delete(url: String): T {
   try {
-    val json = this.delete(url).bodyOrNull<T>() ?: Constants.EMPTY_JSON_RESPONSE
+    val json = this.delete(url).bodyAsTextOrNull() ?: Constants.EMPTY_JSON_RESPONSE
 
-    return localJson.decodeFromString(T::class.serializer(), json.toString())
+    return localJson.decodeFromString(T::class.serializer(), json)
   } catch (e: ResponseException) {
     throw e
   } catch (e: Exception) {
@@ -128,7 +127,7 @@ suspend fun HttpClient.put(
   this.body = body
 }
 
-suspend inline fun <reified T : Any> HttpResponse.bodyOrNull(): T? = when (status) {
+suspend inline fun HttpResponse.bodyAsTextOrNull(): String? = when (status) {
   HttpStatusCode.NoContent -> null
-  else -> body()
+  else -> bodyAsText()
 }

--- a/core/network/src/test/kotlin/com/divinelink/core/network/media/service/ProdMediaServiceTest.kt
+++ b/core/network/src/test/kotlin/com/divinelink/core/network/media/service/ProdMediaServiceTest.kt
@@ -1,0 +1,46 @@
+package com.divinelink.core.network.media.service
+
+import app.cash.turbine.test
+import com.divinelink.core.network.media.model.rating.DeleteRatingRequestApi
+import com.divinelink.core.testing.network.TestRestClient
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class ProdMediaServiceTest {
+
+  private lateinit var service: ProdMediaService
+  private lateinit var testRestClient: TestRestClient
+
+  @BeforeTest
+  fun setUp() {
+    testRestClient = TestRestClient()
+  }
+
+  @Test
+  fun `test delete submit rating with success`() = runTest {
+    testRestClient.mockDelete<Unit>(
+      url = "https://api.themoviedb.org/3/movie/574475/rating?session_id=9b256",
+      response = """
+        {
+          "success": true,
+          "status_code": 13,
+          "status_message": "The item/record was deleted successfully."
+        }
+      """.trimIndent(),
+    )
+
+    service = ProdMediaService(testRestClient.restClient)
+
+    service.deleteRating(
+      DeleteRatingRequestApi.Movie(
+        movieId = 574475,
+        sessionId = "9b256",
+      ),
+    ).test {
+      assertThat(awaitItem()).isEqualTo(Unit)
+      awaitComplete()
+    }
+  }
+}

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/network/TestRestClient.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/network/TestRestClient.kt
@@ -24,4 +24,13 @@ class TestRestClient {
 
     restClient.get<T>(url = url)
   }
+
+  suspend inline fun <reified T : Any> mockDelete(
+    url: String,
+    response: String,
+  ) {
+    restClient = TMDbClient(MockEngine(response))
+
+    restClient.delete<T>(url = url)
+  }
 }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -340,7 +340,6 @@ class DetailsViewModel(
           Timber.d("Rating submitted: $rating")
           _viewState.update { viewState ->
             viewState.copy(
-              showRateDialog = false,
               userDetails = updateOrCreateAccountMediaDetails(rating),
               snackbarMessage = SnackbarMessage.from(
                 text = UIText.ResourceText(
@@ -354,7 +353,6 @@ class DetailsViewModel(
           if (it is SessionException.Unauthenticated) {
             _viewState.update { viewState ->
               viewState.copy(
-                showRateDialog = false,
                 snackbarMessage = SnackbarMessage.from(
                   text = UIText.ResourceText(R.string.details__must_be_logged_in_to_rate),
                   actionLabelText = UIText.ResourceText(R.string.login),
@@ -407,19 +405,10 @@ class DetailsViewModel(
                   viewState.mediaDetails?.title ?: "",
                 ),
               ),
-              showRateDialog = false,
             )
           }
         }
       }
-    }
-  }
-
-  fun onAddRateClicked() {
-    _viewState.update { viewState ->
-      viewState.copy(
-        showRateDialog = true,
-      )
     }
   }
 
@@ -790,12 +779,6 @@ class DetailsViewModel(
   fun consumeSnackbarMessage() {
     _viewState.update { viewState ->
       viewState.copy(snackbarMessage = null)
-    }
-  }
-
-  fun onDismissRateDialog() {
-    _viewState.update { viewState ->
-      viewState.copy(showRateDialog = false)
     }
   }
 

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
@@ -27,7 +27,6 @@ data class DetailsViewState(
   val trailer: Video? = null,
   val error: UIText? = null,
   val snackbarMessage: SnackbarMessage? = null,
-  val showRateDialog: Boolean = false,
   val navigateToLogin: Boolean? = null,
   val menuOptions: List<DetailsMenuOptions> = emptyList(),
   val actionButtons: List<DetailActionItem> = emptyList(),

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/rate/RateDialogContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/rate/RateDialogContent.kt
@@ -5,17 +5,23 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.fromHtml
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.ui.Previews
@@ -27,19 +33,23 @@ import kotlin.math.roundToInt
 fun RateDialogContent(
   modifier: Modifier = Modifier,
   value: Float,
-  onRateChanged: (Float) -> Unit,
   mediaTitle: String,
   canClearRate: Boolean,
   onSubmitRate: (Int) -> Unit,
   onClearRate: () -> Unit,
 ) {
-  val rating = remember { mutableFloatStateOf(value) }
+  var rating by remember { mutableFloatStateOf(value) }
+  val scrollState = rememberScrollState()
 
   Column(
-    modifier = modifier.padding(MaterialTheme.dimensions.keyline_16),
+    modifier = modifier
+      .verticalScroll(scrollState)
+      .padding(MaterialTheme.dimensions.keyline_16),
   ) {
     Text(
-      text = stringResource(id = R.string.details__add_rating_description, mediaTitle),
+      text = AnnotatedString.fromHtml(
+        stringResource(id = R.string.details__add_rating_description, mediaTitle),
+      ),
     )
 
     Spacer(
@@ -51,15 +61,14 @@ fun RateDialogContent(
         .fillMaxWidth()
         .padding(bottom = MaterialTheme.dimensions.keyline_8),
       text = stringResource(id = R.string.details__your_rating),
-      rating = rating.floatValue.roundToInt(),
+      rating = rating.roundToInt(),
     )
 
     RateSlider(
       modifier = Modifier.padding(bottom = MaterialTheme.dimensions.keyline_8),
       value = value,
       onValueChange = {
-        onRateChanged(it)
-        rating.floatValue = it
+        rating = it
       },
     )
 
@@ -76,8 +85,8 @@ fun RateDialogContent(
 
     Button(
       modifier = Modifier.fillMaxWidth(),
-      enabled = rating.floatValue > 0,
-      onClick = { onSubmitRate(rating.floatValue.roundToInt()) },
+      enabled = rating > 0,
+      onClick = { onSubmitRate(rating.roundToInt()) },
     ) {
       Text(
         text = stringResource(id = R.string.details__submit_rating_button),
@@ -94,7 +103,6 @@ private fun BottomSheetRateContentPreview() {
       RateDialogContent(
         value = 5f,
         mediaTitle = "The Godfather",
-        onRateChanged = {},
         onSubmitRate = {},
         onClearRate = {},
         canClearRate = true,
@@ -111,7 +119,6 @@ private fun BottomSheetRateContentWithoutClearPreview() {
       RateDialogContent(
         value = 0f,
         mediaTitle = "The Godfather",
-        onRateChanged = {},
         onSubmitRate = {},
         onClearRate = {},
         canClearRate = false,

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/rate/RateModalBottomSheet.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/rate/RateModalBottomSheet.kt
@@ -32,7 +32,10 @@ fun RateModalBottomSheet(
       value = value?.toFloat() ?: 0f,
       mediaTitle = mediaTitle,
       onSubmitRate = onSubmitRate,
-      onClearRate = onClearRate,
+      onClearRate = {
+        onClearRate()
+        onDismissRequest()
+      },
       canClearRate = canClearRate,
     )
     Spacer(Modifier.windowInsetsBottomHeight(WindowInsets.navigationBarsIgnoringVisibility))

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/rate/RateModalBottomSheet.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/rate/RateModalBottomSheet.kt
@@ -20,7 +20,6 @@ fun RateModalBottomSheet(
   mediaTitle: String,
   canClearRate: Boolean,
   onSubmitRate: (Int) -> Unit,
-  onRateChanged: (Float) -> Unit,
   onClearRate: () -> Unit,
   onDismissRequest: () -> Unit,
 ) {
@@ -32,7 +31,6 @@ fun RateModalBottomSheet(
       modifier = modifier,
       value = value?.toFloat() ?: 0f,
       mediaTitle = mediaTitle,
-      onRateChanged = onRateChanged,
       onSubmitRate = onSubmitRate,
       onClearRate = onClearRate,
       canClearRate = canClearRate,

--- a/feature/details/src/main/res/values/strings.xml
+++ b/feature/details/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
   <string name="feature_details__watchlist">Watchlist</string>
   <string name="details__your_rating">Your rating</string>
   <string name="details__add_rating">Rate this</string>
-  <string name="details__add_rating_description">What do you think of %s?</string>
+  <string name="details__add_rating_description"><![CDATA[What do you think of <b>%s</b>?]]></string>
   <string name="details__clear_my_rating">Clear my rating</string>
   <string name="details__your_score">Your rating %s</string>
   <string name="details__submit_rating_button">Submit rating</string>


### PR DESCRIPTION
### Summary

There was an error when trying to clear rating for a media item that prevented the UI from updating. The issue was caused by the ktor `delete` call expecting a different response type than what the generic bodyOrNull() function was providing. 

Also made some additional ui improvements and simplified the bottom sheet visibility logic. 