### PR TITLE
Redesign and declutter media item card 

### DIFF
--- a/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/HomeContent.kt
+++ b/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/HomeContent.kt
@@ -28,7 +28,6 @@ import com.divinelink.scenepeek.ui.composables.transitionspec.fadeTransitionSpec
 fun HomeContent(
   viewState: HomeViewState,
   modifier: Modifier = Modifier,
-  onMarkAsFavoriteClicked: (MediaItem) -> Unit,
   onLoadNextPage: () -> Unit,
   onNavigateToDetails: (MediaItem) -> Unit,
   onFilterClick: (Filter) -> Unit,
@@ -70,14 +69,12 @@ fun HomeContent(
               modifier = modifier,
               section = viewState.popularMovies,
               onMediaClick = onNavigateToDetails,
-              onMarkAsFavoriteClick = onMarkAsFavoriteClicked,
               onLoadNextPage = onLoadNextPage,
             )
             HomeMode.Filtered -> MediaContent(
               modifier = modifier,
               section = viewState.filteredResults,
               onMediaClick = onNavigateToDetails,
-              onMarkAsFavoriteClick = onMarkAsFavoriteClicked,
               onLoadNextPage = onLoadNextPage,
             )
           }
@@ -123,7 +120,6 @@ fun HomeContentPreview() {
           mode = HomeMode.Browser,
           retryAction = null,
         ),
-        onMarkAsFavoriteClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},

--- a/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/HomeScreen.kt
+++ b/app/src/main/kotlin/com/divinelink/scenepeek/home/ui/HomeScreen.kt
@@ -83,7 +83,6 @@ fun HomeScreen(
       HomeContent(
         modifier = Modifier,
         viewState = viewState,
-        onMarkAsFavoriteClicked = viewModel::onMarkAsFavoriteClicked,
         onLoadNextPage = viewModel::onLoadNextPage,
         onNavigateToDetails = { media ->
           when (media) {

--- a/app/src/test/kotlin/com/divinelink/ui/home/HomeContentTest.kt
+++ b/app/src/test/kotlin/com/divinelink/ui/home/HomeContentTest.kt
@@ -28,7 +28,6 @@ class HomeContentTest : ComposeTest() {
     setContentWithTheme {
       HomeContent(
         viewState = uiState,
-        onMarkAsFavoriteClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
@@ -54,7 +53,6 @@ class HomeContentTest : ComposeTest() {
     setContentWithTheme {
       HomeContent(
         viewState = uiState,
-        onMarkAsFavoriteClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
@@ -83,7 +81,6 @@ class HomeContentTest : ComposeTest() {
     setContentWithTheme {
       HomeContent(
         viewState = uiState,
-        onMarkAsFavoriteClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
@@ -108,7 +105,6 @@ class HomeContentTest : ComposeTest() {
     setContentWithTheme {
       HomeContent(
         viewState = uiState,
-        onMarkAsFavoriteClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},
@@ -137,7 +133,6 @@ class HomeContentTest : ComposeTest() {
     setContentWithTheme {
       HomeContent(
         viewState = uiState,
-        onMarkAsFavoriteClicked = {},
         onLoadNextPage = {},
         onNavigateToDetails = {},
         onFilterClick = {},

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/CreditMediaItem.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/CreditMediaItem.kt
@@ -1,14 +1,10 @@
 package com.divinelink.core.ui
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
@@ -18,7 +14,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -28,9 +23,8 @@ import androidx.compose.ui.unit.dp
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.model.media.MediaItem
+import com.divinelink.core.ui.media.MediaImage
 import com.divinelink.core.ui.provider.MediaItemParameterProvider
-import com.divinelink.core.ui.rating.RatingSize
-import com.divinelink.core.ui.rating.TMDBRatingItem
 
 @Composable
 fun CreditMediaItem(
@@ -39,7 +33,6 @@ fun CreditMediaItem(
   subtitle: String? = null,
   onClick: (MediaItem.Media) -> Unit,
 ) {
-  val offset = MaterialTheme.dimensions.keyline_28
   Card(
     modifier = modifier.testTag(TestTags.Person.CREDIT_MEDIA_ITEM.format(mediaItem.name)),
     onClick = { onClick(mediaItem) },
@@ -52,28 +45,10 @@ fun CreditMediaItem(
         .wrapContentSize()
         .fillMaxWidth(),
     ) {
-      Column {
-        Box(
-          modifier = Modifier.widthIn(max = 80.dp),
-          contentAlignment = Alignment.Center,
-        ) {
-          MovieImage(
-            path = mediaItem.posterPath,
-          )
-          if (mediaItem.voteAverage > 0 && mediaItem.voteCount > 0) {
-            TMDBRatingItem(
-              modifier = Modifier
-                .align(Alignment.BottomStart)
-                .offset(y = offset)
-                .padding(start = MaterialTheme.dimensions.keyline_8),
-              rating = mediaItem.voteAverage,
-              voteCount = mediaItem.voteCount,
-              size = RatingSize.MEDIUM,
-            )
-          }
-        }
-        Spacer(modifier = Modifier.height(offset))
-      }
+      MediaImage(
+        media = mediaItem,
+        modifier = Modifier.widthIn(max = MaterialTheme.dimensions.keyline_96),
+      )
 
       Column(
         modifier = Modifier

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/DetailedMediaItem.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/DetailedMediaItem.kt
@@ -2,15 +2,11 @@ package com.divinelink.core.ui
 
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentSize
@@ -29,10 +25,9 @@ import androidx.compose.ui.unit.dp
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.model.media.MediaItem
+import com.divinelink.core.ui.media.MediaImage
 import com.divinelink.core.ui.provider.MediaItemParameterProvider
-import com.divinelink.core.ui.rating.RatingSize
 import com.divinelink.core.ui.rating.StarRatingItem
-import com.divinelink.core.ui.rating.TMDBRatingItem
 
 @Composable
 fun DetailedMediaItem(
@@ -57,26 +52,10 @@ fun DetailedMediaItem(
         .wrapContentSize()
         .fillMaxWidth(),
     ) {
-      Column {
-        Box(
-          modifier = Modifier.widthIn(max = 80.dp),
-          contentAlignment = Alignment.Center,
-        ) {
-          MovieImage(
-            path = mediaItem.posterPath,
-          )
-          TMDBRatingItem(
-            modifier = Modifier
-              .align(Alignment.BottomStart)
-              .offset(y = offset)
-              .padding(start = MaterialTheme.dimensions.keyline_8),
-            rating = mediaItem.voteAverage,
-            voteCount = mediaItem.voteCount,
-            size = RatingSize.MEDIUM,
-          )
-        }
-        Spacer(modifier = Modifier.height(offset))
-      }
+      MediaImage(
+        media = mediaItem,
+        modifier = Modifier.widthIn(max = MaterialTheme.dimensions.keyline_96),
+      )
 
       Column(
         Modifier

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/MediaItem.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/MediaItem.kt
@@ -1,37 +1,32 @@
 package com.divinelink.core.ui.components
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.divinelink.core.designsystem.theme.AppTheme
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.designsystem.theme.shape
 import com.divinelink.core.model.media.MediaItem
-import com.divinelink.core.ui.FavoriteButton
-import com.divinelink.core.ui.MovieImage
 import com.divinelink.core.ui.Previews
+import com.divinelink.core.ui.media.MediaImage
 import com.divinelink.core.ui.provider.MediaItemParameterProvider
-import com.divinelink.core.ui.rating.TMDBRatingItem
 
 const val MOVIE_CARD_ITEM_TAG = "MOVIE_CARD_ITEM_TAG"
 
@@ -40,12 +35,9 @@ fun MediaItem(
   modifier: Modifier = Modifier,
   media: MediaItem.Media,
   subtitle: String? = null,
-  fullDate: Boolean = true,
+  showDate: Boolean = false,
   onMediaItemClick: (MediaItem.Media) -> Unit,
-  onLikeMediaClick: () -> Unit = {},
 ) {
-  val offset = MaterialTheme.dimensions.keyline_28
-
   Card(
     shape = MaterialTheme.shape.medium,
     modifier = modifier
@@ -58,80 +50,50 @@ fun MediaItem(
       },
     colors = CardDefaults.cardColors(containerColor = Color.Transparent),
   ) {
-    Box(
-      contentAlignment = Alignment.Center,
-      modifier = Modifier
-        .fillMaxWidth()
-        .wrapContentHeight(),
-    ) {
-      MovieImage(
-        path = media.posterPath,
-      )
-      media.isFavorite?.let { isFavorite ->
-        FavoriteButton(
-          modifier = Modifier.align(Alignment.TopStart),
-          isFavorite = isFavorite,
-          onClick = onLikeMediaClick,
-        )
-      }
-
-      TMDBRatingItem(
-        modifier = Modifier
-          .align(Alignment.BottomStart)
-          .offset(y = offset)
-          .padding(start = MaterialTheme.dimensions.keyline_8),
-        rating = media.voteAverage,
-        voteCount = media.voteCount,
-      )
-    }
+    MediaImage(media = media)
 
     Spacer(modifier = Modifier.height(MaterialTheme.dimensions.keyline_4))
 
     Text(
       modifier = Modifier
         .fillMaxWidth()
-        .padding(horizontal = MaterialTheme.dimensions.keyline_8)
-        .offset(y = offset)
-        .height(MaterialTheme.dimensions.keyline_58),
+        .padding(bottom = MaterialTheme.dimensions.keyline_4)
+        .padding(horizontal = MaterialTheme.dimensions.keyline_8),
       text = media.name,
       maxLines = 3,
       overflow = TextOverflow.Ellipsis,
-      style = MaterialTheme.typography.titleSmall,
+      style = MaterialTheme.typography.bodySmall,
+      fontWeight = MaterialTheme.typography.titleSmall.fontWeight,
       color = MaterialTheme.colorScheme.onSurface,
+      textAlign = TextAlign.Center,
     )
 
-    subtitle?.let {
+    if (!subtitle.isNullOrBlank()) {
       Text(
         modifier = Modifier
           .fillMaxWidth()
-          .offset(y = offset)
-          .padding(top = MaterialTheme.dimensions.keyline_4)
           .padding(horizontal = MaterialTheme.dimensions.keyline_8),
         text = subtitle,
         maxLines = 1,
-        style = MaterialTheme.typography.bodySmall,
+        style = MaterialTheme.typography.labelSmall,
         overflow = TextOverflow.Ellipsis,
         color = MaterialTheme.colorScheme.primary,
+        textAlign = TextAlign.Center,
       )
     }
 
-    Text(
-      modifier = Modifier
-        .offset(y = offset)
-        .padding(
-          vertical = MaterialTheme.dimensions.keyline_4,
-          horizontal = MaterialTheme.dimensions.keyline_8,
-        ),
-      text = if (fullDate) {
-        media.releaseDate
-      } else {
-        media.releaseDate.take(4)
-      },
-      style = MaterialTheme.typography.labelMedium,
-      color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-
-    Spacer(modifier = Modifier.height(offset))
+    if (showDate) {
+      Text(
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(vertical = MaterialTheme.dimensions.keyline_4)
+          .padding(horizontal = MaterialTheme.dimensions.keyline_8),
+        text = media.releaseDate.take(4),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        textAlign = TextAlign.Center,
+      )
+    }
   }
 }
 
@@ -146,7 +108,6 @@ fun MediaItemPreview(
         modifier = Modifier,
         media = mediaItem,
         onMediaItemClick = {},
-        onLikeMediaClick = {},
       )
     }
   }
@@ -164,7 +125,6 @@ fun MediaItemWithSubtitlePreview(
         media = mediaItem,
         subtitle = "Matthew Walkers",
         onMediaItemClick = {},
-        onLikeMediaClick = {},
       )
     }
   }

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/media/FlatMediaList.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/media/FlatMediaList.kt
@@ -42,7 +42,6 @@ fun FlatMediaList(
   modifier: Modifier = Modifier,
   data: List<MediaItem>,
   onItemClick: (MediaItem) -> Unit,
-  onMarkAsFavoriteClicked: (MediaItem) -> Unit,
   onLoadNextPage: () -> Unit,
   isLoading: Boolean,
 ) {
@@ -72,12 +71,10 @@ fun FlatMediaList(
         is MediaItem.Media.Movie -> MediaItem(
           media = search,
           onMediaItemClick = { onItemClick(search) },
-          onLikeMediaClick = { onMarkAsFavoriteClicked(search) },
         )
         is MediaItem.Media.TV -> MediaItem(
           media = search,
           onMediaItemClick = { onItemClick(search) },
-          onLikeMediaClick = { onMarkAsFavoriteClicked(search) },
         )
         is MediaItem.Person -> CreditsItemCard(
           // TODO FIX Duplicate model
@@ -140,7 +137,6 @@ fun MoviesListScreenPreview() {
       FlatMediaList(
         data = MediaItemFactory.MoviesList(),
         onItemClick = {},
-        onMarkAsFavoriteClicked = {},
         onLoadNextPage = {},
         isLoading = true,
       )

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/media/MediaContent.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/media/MediaContent.kt
@@ -12,7 +12,6 @@ fun MediaContent(
   modifier: Modifier = Modifier,
   section: MediaSection?,
   onMediaClick: (MediaItem) -> Unit,
-  onMarkAsFavoriteClick: (MediaItem) -> Unit,
   onLoadNextPage: () -> Unit,
 ) {
   if (section == null) return
@@ -21,7 +20,6 @@ fun MediaContent(
     modifier = modifier.testTag(MEDIA_LIST_TAG),
     data = section.data,
     onItemClick = onMediaClick,
-    onMarkAsFavoriteClicked = onMarkAsFavoriteClick,
     onLoadNextPage = onLoadNextPage,
     isLoading = section.shouldLoadMore,
   )

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/media/MediaImage.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/media/MediaImage.kt
@@ -1,0 +1,69 @@
+package com.divinelink.core.ui.media
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.divinelink.core.designsystem.theme.colors
+import com.divinelink.core.designsystem.theme.dimensions
+import com.divinelink.core.model.media.MediaItem
+import com.divinelink.core.ui.MovieImage
+import com.divinelink.core.ui.rating.DiscreetRatingItem
+
+@Composable
+fun MediaImage(
+  media: MediaItem.Media,
+  modifier: Modifier = Modifier,
+) {
+  Box(
+    contentAlignment = Alignment.Center,
+    modifier = modifier
+      .wrapContentHeight(),
+  ) {
+    MovieImage(
+      path = media.posterPath,
+    )
+
+    if (media.isFavorite == true) {
+      Surface(
+        modifier = Modifier
+          .offset(
+            x = -MaterialTheme.dimensions.keyline_8,
+            y = MaterialTheme.dimensions.keyline_8,
+          )
+          .size(MaterialTheme.dimensions.keyline_20)
+          .align(Alignment.BottomEnd),
+        color = MaterialTheme.colors.crimsonRed,
+        shape = CircleShape,
+      ) {
+        Icon(
+          modifier = Modifier.padding(MaterialTheme.dimensions.keyline_4),
+          imageVector = Icons.Default.Favorite,
+          tint = Color.White,
+          contentDescription = null,
+        )
+      }
+    }
+
+    DiscreetRatingItem(
+      modifier = Modifier
+        .align(Alignment.TopEnd)
+        .padding(
+          end = MaterialTheme.dimensions.keyline_4,
+          top = MaterialTheme.dimensions.keyline_4,
+        ),
+      rating = media.voteAverage,
+    )
+  }
+}

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/rating/DiscreetRatingItem.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/rating/DiscreetRatingItem.kt
@@ -1,0 +1,119 @@
+package com.divinelink.core.ui.rating
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import com.divinelink.core.commons.extensions.isWholeNumber
+import com.divinelink.core.commons.extensions.round
+import com.divinelink.core.designsystem.theme.AppTheme
+import com.divinelink.core.designsystem.theme.LocalDarkThemeProvider
+import com.divinelink.core.designsystem.theme.dimensions
+import com.divinelink.core.ui.Previews
+import com.divinelink.core.ui.extension.getColorRating
+
+@Composable
+fun DiscreetRatingItem(
+  modifier: Modifier = Modifier,
+  rating: Double?,
+) {
+  val sanitizedRating = if (rating == null) {
+    null
+  } else {
+    if (rating.isWholeNumber()) {
+      rating.toInt()
+    } else {
+      rating.round(1)
+    }
+  }
+
+  if (sanitizedRating == 0 || sanitizedRating?.toString() == null) return
+
+  val backgroundColor = if (LocalDarkThemeProvider.current) {
+    MaterialTheme.colorScheme.surface.copy(alpha = 0.7f)
+  } else {
+    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+  }
+
+  val textColor = if (LocalDarkThemeProvider.current) {
+    MaterialTheme.colorScheme.onSurface
+  } else {
+    MaterialTheme.colorScheme.surface
+  }
+
+  CompositionLocalProvider(
+    LocalDensity provides Density(
+      density = LocalDensity.current.density,
+      fontScale = LocalDensity.current.fontScale.coerceIn(1f, 1.35f),
+    ),
+  ) {
+    Surface(
+      modifier = modifier.widthIn(min = MaterialTheme.dimensions.keyline_26),
+      color = backgroundColor,
+      shape = MaterialTheme.shapes.small,
+
+    ) {
+      Text(
+        modifier = Modifier.padding(MaterialTheme.dimensions.keyline_4),
+        text = sanitizedRating.toString(),
+        style = MaterialTheme.typography.bodySmall,
+        fontWeight = MaterialTheme.typography.titleSmall.fontWeight,
+        textAlign = TextAlign.Center,
+        color = textColor, // sanitizedRating.toDouble().getColorRating(),
+      )
+    }
+  }
+}
+
+@Previews
+@Composable
+fun DiscreetRatingItemPreview() {
+  AppTheme {
+    Surface {
+      Column {
+        Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_8)) {
+          DiscreetRatingItem(rating = null)
+          DiscreetRatingItem(rating = null)
+          DiscreetRatingItem(rating = null)
+          DiscreetRatingItem(rating = null)
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_8)) {
+          DiscreetRatingItem(rating = 5.4)
+          DiscreetRatingItem(rating = 5.0)
+          DiscreetRatingItem(rating = 5.0)
+          DiscreetRatingItem(rating = 5.4)
+          DiscreetRatingItem(rating = 5.0)
+          DiscreetRatingItem(rating = 5.0)
+        }
+
+        Row(
+          horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_8),
+        ) {
+          DiscreetRatingItem(rating = 1.1)
+          DiscreetRatingItem(rating = 1.1)
+          DiscreetRatingItem(rating = 5.9)
+        }
+        Row(
+          horizontalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_8),
+        ) {
+          DiscreetRatingItem(rating = 0.0)
+          DiscreetRatingItem(rating = 0.0)
+          DiscreetRatingItem(rating = 9.2)
+          DiscreetRatingItem(rating = 9.2)
+        }
+      }
+    }
+  }
+}

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/rating/TMDBRatingItem.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/rating/TMDBRatingItem.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -40,15 +39,15 @@ enum class RatingSize(
   val coloredArcSize: Dp,
 ) {
   SMALL(
-    size = 40.dp,
+    size = 36.dp,
     coloredArcSize = 28.dp,
   ),
   MEDIUM(
-    size = 48.dp,
-    coloredArcSize = 36.dp,
+    size = 44.dp,
+    coloredArcSize = 38.dp,
   ),
   LARGE(
-    size = 68.dp,
+    size = 64.dp,
     coloredArcSize = 56.dp,
   ),
 }
@@ -79,7 +78,7 @@ fun TMDBRatingItem(
   }
 
   val textSize = when (size) {
-    RatingSize.SMALL -> MaterialTheme.typography.labelMedium
+    RatingSize.SMALL -> MaterialTheme.typography.labelSmall
     RatingSize.MEDIUM -> MaterialTheme.typography.labelMedium
     RatingSize.LARGE -> MaterialTheme.typography.titleMedium
   }
@@ -87,8 +86,7 @@ fun TMDBRatingItem(
   Box(
     contentAlignment = Alignment.Center,
     modifier = modifier
-      .testTag(TestTags.Rating.TMDB_RATING)
-      .padding(vertical = MaterialTheme.dimensions.keyline_4),
+      .testTag(TestTags.Rating.TMDB_RATING),
   ) {
     Canvas(modifier = Modifier.size(size.size)) {
       drawArc(
@@ -108,8 +106,8 @@ fun TMDBRatingItem(
         sweepAngle = 360f,
         useCenter = true,
         style = Stroke(
-          width = 4.dp.toPx(),
-          miter = 4f,
+          width = 2.dp.toPx(),
+          miter = 2f,
         ),
       )
       drawArc(
@@ -118,7 +116,7 @@ fun TMDBRatingItem(
         sweepAngle = (100f / 10f * (rating?.round(1) ?: 0.0) * 3.6f).toFloat(),
         useCenter = false,
         style = Stroke(
-          width = 4.dp.toPx(),
+          width = 2.dp.toPx(),
           miter = 2f,
           cap = StrokeCap.Round,
         ),

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/forms/about/AboutFormContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/forms/about/AboutFormContent.kt
@@ -57,12 +57,12 @@ fun AboutFormContent(
           style = MaterialTheme.typography.bodyMedium,
         )
       }
-      item {
-        HorizontalDivider()
-      }
     }
 
     aboutData.genres?.let { genres ->
+      item {
+        HorizontalDivider()
+      }
       item {
         GenresSection(genres, onGenreClick)
       }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/person/ui/PersonGridContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/person/ui/PersonGridContent.kt
@@ -128,7 +128,7 @@ internal fun PersonGridContent(
                 .animateContentSize(),
               media = item.mediaItem,
               subtitle = item.role.title,
-              fullDate = false,
+              showDate = true,
               onMediaItemClick = onMediaClick,
             )
           } else {

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/person/ui/credits/KnownForSection.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/person/ui/credits/KnownForSection.kt
@@ -53,9 +53,8 @@ fun KnownForSection(
           MediaItem(
             media = credit.mediaItem,
             subtitle = credit.role.title,
-            fullDate = false,
+            showDate = true,
             onMediaItemClick = onMediaClick,
-            onLikeMediaClick = { /* Do nothing */ },
           )
         }
       }

--- a/feature/search/src/main/kotlin/com/divinelink/feature/search/ui/SearchContent.kt
+++ b/feature/search/src/main/kotlin/com/divinelink/feature/search/ui/SearchContent.kt
@@ -64,7 +64,6 @@ fun SearchContent(
           }
         }
       },
-      onMarkAsFavoriteClick = onMarkAsFavorite,
       onLoadNextPage = onLoadNextPage,
     )
 


### PR DESCRIPTION
### Summary
Redesign media item card by simplifying media rating and favorite status. 

## Changes
- Replace TMDB's circular rating component on media card with plain text rating
- Remove date from home media cards
- Update favorite status to a more minimal one (this also removes the ability to mark as favorite a movie directly from the card, but its questionable if that functionality was any useful at all - future PR will add dialog menu on long press which will have the mark as favorite option there)
- Media title is not center aligned

## Screenshots
| Home | Person |
|---------|---------|
| <img width="1080" height="2340" alt="Screenshot_20250815_165706" src="https://github.com/user-attachments/assets/40ebb962-6eb5-4060-908f-a17006a289a1" /> | <img width="1080" height="2340" alt="Screenshot_20250815_165847" src="https://github.com/user-attachments/assets/be4bbe3b-a0d3-4417-aa80-0a6b2a225898" /> |
