### PR TITLE
Display error dialog on jellyseerr login and allow to share error code

### DIFF
--- a/app/src/main/kotlin/com/divinelink/scenepeek/provider/AndroidBuildConfigProvider.kt
+++ b/app/src/main/kotlin/com/divinelink/scenepeek/provider/AndroidBuildConfigProvider.kt
@@ -11,5 +11,5 @@ class AndroidBuildConfigProvider : BuildConfigProvider {
   override val versionName: String
     get() = BuildConfig.VERSION_NAME
   override val versionData: String
-    get() = "${BuildConfig.VERSION_NAME} ${BuildConfig.VERSION_CODE}"
+    get() = "${BuildConfig.VERSION_NAME} (${BuildConfig.VERSION_CODE})"
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-  <string name="ok">OK</string>
   <string name="close">Close</string>
   <string name="save">Save</string>
   <string name="update">Update</string>
@@ -9,7 +8,6 @@
 
   <!-- Error -->
   <string name="empty_field_error_message">%s is required.</string>
-  <string name="general_error_title">An error occurred</string>
   <string name="general_error_message">Something when wrong.</string>
 
   <string name="delete">Delete</string>

--- a/app/src/test/kotlin/com/divinelink/ui/details/DetailsContentTest.kt
+++ b/app/src/test/kotlin/com/divinelink/ui/details/DetailsContentTest.kt
@@ -35,12 +35,12 @@ import com.divinelink.core.testing.getString
 import com.divinelink.core.testing.setVisibilityScopeContent
 import com.divinelink.core.ui.TestTags
 import com.divinelink.core.ui.TestTags.LOADING_CONTENT
+import com.divinelink.core.ui.UiString
 import com.divinelink.factories.VideoFactory
 import com.divinelink.factories.details.domain.model.account.AccountMediaDetailsFactory
 import com.divinelink.factories.details.domain.model.account.AccountMediaDetailsFactory.toWizard
 import com.divinelink.feature.details.media.ui.DetailsContent
 import com.divinelink.feature.details.media.ui.DetailsViewState
-import com.divinelink.scenepeek.R
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -229,7 +229,7 @@ class DetailsContentTest : ComposeTest() {
       .getString(detailsR.string.details__fatal_error_fetching_details)
 
     val okText = composeTestRule.activity
-      .getString(R.string.ok)
+      .getString(UiString.core_ui_okay)
 
     composeTestRule
       .onNodeWithText(errorText)

--- a/core/network/src/main/kotlin/com/divinelink/core/network/client/KtorClient.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/client/KtorClient.kt
@@ -87,15 +87,15 @@ fun ktorClient(engine: HttpClientEngine): HttpClient = HttpClient(engine) {
     handleResponseExceptionWithRequest { cause, request ->
       Timber.e("Exception occurred: $cause, URL: ${request.url}")
       val dataError = when (cause) {
-        is SocketTimeoutException -> AppException.SocketTimeout(cause.message)
-        is ConnectTimeoutException -> AppException.ConnectionTimeout(cause.message)
-        is HttpRequestTimeoutException -> AppException.RequestTimeout(cause.message)
-        is SSLHandshakeException -> AppException.Ssl(cause.message)
-        is SerializationException -> AppException.Serialization(cause.message)
-        is ConnectException -> AppException.Offline(cause.message)
-        is UnknownHostException -> AppException.Offline(cause.message)
+        is SocketTimeoutException -> AppException.SocketTimeout(cause.toString())
+        is ConnectTimeoutException -> AppException.ConnectionTimeout(cause.toString())
+        is HttpRequestTimeoutException -> AppException.RequestTimeout(cause.toString())
+        is SSLHandshakeException -> AppException.Ssl(cause.toString())
+        is SerializationException -> AppException.Serialization(cause.toString())
+        is ConnectException -> AppException.Offline(cause.toString())
+        is UnknownHostException -> AppException.Offline(cause.toString())
         is AppException -> cause
-        else -> AppException.Unknown(cause.message)
+        else -> AppException.Unknown(cause.toString())
       }
       throw dataError
     }

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/ViewModelTestRobot.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/ViewModelTestRobot.kt
@@ -13,7 +13,7 @@ abstract class ViewModelTestRobot<T> {
 }
 
 fun <T, R : ViewModelTestRobot<T>> R.assertUiState(expectedUiState: T) = apply {
-  assertThat((actualUiState as StateFlow).value).isEqualTo(expectedUiState)
+  assertThat((actualUiState as StateFlow).value.toString()).isEqualTo(expectedUiState.toString())
 }
 
 fun <T, R : ViewModelTestRobot<T>> R.assertUiStateNotEqualTo(expectedUiState: T) = apply {

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/TestTags.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/TestTags.kt
@@ -140,6 +140,7 @@ object TestTags {
     const val ALERT_DIALOG = "Dialogs Alert Dialog"
     const val CONFIRM_BUTTON = "Dialog Confirm Button"
     const val DISMISS_BUTTON = "Dialog Dismiss Button"
+    const val SHARE_ERROR_BUTTON = "Share Error Button"
     const val DELETE_REQUEST = "Delete Request Dialog"
     const val REMOVE_ITEMS_FROM_LIST = "Remove Items From List"
 

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/Utilities.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/Utilities.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
+typealias UiString = R.string
+
 @Stable
 object UiTokens {
 

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/dialog/AlertDialogUiState.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/dialog/AlertDialogUiState.kt
@@ -2,8 +2,9 @@ package com.divinelink.core.ui.components.dialog
 
 import com.divinelink.core.model.UIText
 import com.divinelink.core.ui.R
+import com.divinelink.core.ui.UiString
 
 data class AlertDialogUiState(
-  val title: UIText = UIText.ResourceText(R.string.general_error_title),
+  val title: UIText = UIText.ResourceText(UiString.core_ui_general_error_title),
   val text: UIText,
 )

--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/components/dialog/BasicDialog.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/components/dialog/BasicDialog.kt
@@ -1,0 +1,79 @@
+package com.divinelink.core.ui.components.dialog
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
+import com.divinelink.core.model.UIText
+import com.divinelink.core.ui.TestTags
+import com.divinelink.core.ui.UiString
+import com.divinelink.core.ui.composition.LocalIntentManager
+import com.divinelink.core.ui.getString
+import com.divinelink.core.ui.manager.IntentManager
+
+@Composable
+fun BasicDialog(
+  dialogState: DialogState,
+  onConfirm: () -> Unit = {},
+  onDismissRequest: () -> Unit,
+  intentManager: IntentManager = LocalIntentManager.current,
+) {
+  AlertDialog(
+    onDismissRequest = onDismissRequest,
+    confirmButton = {
+      TextButton(
+        content = {
+          Text(text = stringResource(id = UiString.core_ui_okay))
+        },
+        onClick = {
+          onConfirm()
+          onDismissRequest()
+        },
+        modifier = Modifier.testTag(TestTags.Dialogs.CONFIRM_BUTTON),
+      )
+    },
+    dismissButton = dialogState.error?.let { error ->
+      {
+        TextButton(
+          content = {
+            Text(text = stringResource(id = UiString.core_ui_share_error_details))
+          },
+          onClick = {
+            intentManager.shareErrorReport(throwable = error)
+            onDismissRequest()
+          },
+          modifier = Modifier.testTag(TestTags.Dialogs.SHARE_ERROR_BUTTON),
+        )
+      }
+    },
+    title = dialogState.title?.getString()?.let {
+      {
+        Text(
+          text = it,
+          style = MaterialTheme.typography.headlineSmall,
+        )
+      }
+    },
+    text = {
+      Text(
+        text = dialogState.message.getString(),
+        style = MaterialTheme.typography.bodyMedium,
+      )
+    },
+    modifier = Modifier.semantics {
+      testTag = TestTags.Dialogs.ALERT_DIALOG
+    },
+  )
+}
+
+data class DialogState(
+  val title: UIText? = null,
+  val message: UIText,
+  val error: Throwable?,
+)

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="core_ui_ok">OK</string>
+  <string name="core_ui_okay">Okay</string>
   <string name="core_ui_cancel">Cancel</string>
   <string name="core_ui_confirm">Confirm</string>
   <string name="core_ui_delete">Delete</string>
+  <string name="core_ui_share_error_details">Share error details</string>
 
   <string name="core_ui_save">Save</string>
   <string name="core_ui_play_trailer">Watch Trailer</string>
@@ -36,7 +37,7 @@
     <item quantity="other">(%s Episodes)</item>
   </plurals>
 
-  <string name="general_error_title">An error occurred</string>
+  <string name="core_ui_general_error_title">An error has occurred</string>
 
   <string name="core_ui_review_author">A review by: %s, %s</string>
   <string name="details__reviews">Reviews</string>

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
@@ -68,6 +68,7 @@ import com.divinelink.core.ui.FavoriteButton
 import com.divinelink.core.ui.Previews
 import com.divinelink.core.ui.SharedTransitionScopeProvider
 import com.divinelink.core.ui.TestTags
+import com.divinelink.core.ui.UiString
 import com.divinelink.core.ui.blankslate.BlankSlate
 import com.divinelink.core.ui.blankslate.BlankSlateState
 import com.divinelink.core.ui.components.AppTopAppBar
@@ -92,7 +93,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
-import com.divinelink.core.ui.R as uiR
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -305,7 +305,7 @@ fun DetailsContent(
         if (viewState.error != null) {
           SimpleAlertDialog(
             confirmClick = { onNavigate(Navigation.Back) },
-            confirmText = UIText.ResourceText(uiR.string.core_ui_ok),
+            confirmText = UIText.ResourceText(UiString.core_ui_okay),
             uiState = AlertDialogUiState(text = viewState.error),
           )
         }

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrInteraction.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrInteraction.kt
@@ -9,4 +9,5 @@ sealed interface JellyseerrInteraction {
   data class OnSelectLoginMethod(val signInMethod: JellyseerrAuthMethod) : JellyseerrInteraction
   data object OnLoginClick : JellyseerrInteraction
   data object OnLogoutClick : JellyseerrInteraction
+  data object OnDismissDialog : JellyseerrInteraction
 }

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrLoginContent.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrLoginContent.kt
@@ -94,7 +94,10 @@ fun JellyseerrLoginContent(
         ),
         singleLine = true,
         onValueChange = { interaction(JellyseerrInteraction.OnAddressChange(it)) },
-        label = { Text(text = stringResource(R.string.feature_settings_jellyseerr_address)) },
+        label = { Text(text = stringResource(R.string.feature_settings_jellyseerr_server_url)) },
+        placeholder = {
+          Text(text = stringResource(R.string.feature_settings_jellyseerr_address_placeholder))
+        },
       )
     }
 

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsScreen.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsScreen.kt
@@ -2,7 +2,6 @@ package com.divinelink.feature.settings.app.account.jellyseerr
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibilityScope
-
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -12,6 +11,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.divinelink.core.model.jellyseerr.JellyseerrState
 import com.divinelink.core.ui.TestTags
+import com.divinelink.core.ui.components.dialog.BasicDialog
 import com.divinelink.core.ui.snackbar.SnackbarMessageHandler
 import com.divinelink.feature.settings.R
 import com.divinelink.feature.settings.components.SettingsScaffold
@@ -30,6 +30,13 @@ fun AnimatedVisibilityScope.JellyseerrSettingsScreen(
     snackbarMessage = uiState.snackbarMessage,
     onDismissSnackbar = viewModel::dismissSnackbar,
   )
+
+  uiState.dialogState?.let { state ->
+    BasicDialog(
+      dialogState = state,
+      onDismissRequest = { viewModel.onJellyseerrInteraction(JellyseerrInteraction.OnDismissDialog) },
+    )
+  }
 
   SettingsScaffold(
     animatedVisibilityScope = this@JellyseerrSettingsScreen,

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsUiState.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsUiState.kt
@@ -1,15 +1,18 @@
 package com.divinelink.feature.settings.app.account.jellyseerr
 
 import com.divinelink.core.model.jellyseerr.JellyseerrState
+import com.divinelink.core.ui.components.dialog.DialogState
 import com.divinelink.core.ui.snackbar.SnackbarMessage
 
 data class JellyseerrSettingsUiState(
   val snackbarMessage: SnackbarMessage?,
+  val dialogState: DialogState?,
   val jellyseerrState: JellyseerrState,
 ) {
   companion object {
     fun initial(): JellyseerrSettingsUiState = JellyseerrSettingsUiState(
       snackbarMessage = null,
+      dialogState = null,
       jellyseerrState = JellyseerrState.Login(
         isLoading = false,
       ),

--- a/feature/settings/src/main/res/values/strings.xml
+++ b/feature/settings/src/main/res/values/strings.xml
@@ -26,7 +26,8 @@
   <string name="feature_settings_could_not_connect">Could not connect to server. Make sure the IP address is correct and the server is running.</string>
 
   <string name="feature_settings_jellyseerr_description">Add your Jellyseerr IP Address and select a sign-in method to enable Jellyseerr.\nMake sure to include the full URL with https:// or http:// and port number if needed.</string>
-  <string name="feature_settings_jellyseerr_address">http(s)://your-jellyseerr-server.com</string>
+  <string name="feature_settings_jellyseerr_server_url">Server URL</string>
+  <string name="feature_settings_jellyseerr_address_placeholder">ex. http(s)://your-jellyseerr-url.com</string>
 
   <string name="feature_settings_sign_in_with">Sign in with %s</string>
   <string name="feature_settings_signing_in">Signing in…</string>

--- a/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModelTestRobot.kt
+++ b/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModelTestRobot.kt
@@ -64,8 +64,10 @@ class JellyseerrSettingsViewModelTestRobot : ViewModelTestRobot<JellyseerrSettin
     viewModel.onJellyseerrInteraction(JellyseerrInteraction.OnSelectLoginMethod(method))
   }
 
-  suspend fun onLoginJellyseerr(result: Result<JellyseerrAccountDetailsResult>) = apply {
-    accountDetailsChannel.send(result)
+  suspend fun onLoginJellyseerr(result: Result<JellyseerrAccountDetailsResult>? = null) = apply {
+    result?.let {
+      accountDetailsChannel.send(result)
+    }
     viewModel.onJellyseerrInteraction(JellyseerrInteraction.OnLoginClick)
   }
 
@@ -77,6 +79,10 @@ class JellyseerrSettingsViewModelTestRobot : ViewModelTestRobot<JellyseerrSettin
 
   fun onDismissSnackbar() = apply {
     viewModel.dismissSnackbar()
+  }
+
+  fun onDismissDialog() = apply {
+    viewModel.onJellyseerrInteraction(JellyseerrInteraction.OnDismissDialog)
   }
 
   override val actualUiState: Flow<JellyseerrSettingsUiState>


### PR DESCRIPTION
### Summary  

To easily catch and solve server-related issues on Jellyseerr, we replaced the snackbar message with an alert dialog while also giving to the user the option to share the error response using the intent manager implemented on #171.