### PR TITLE
Adding network layer for fetching radarr and sonarr instance

### DIFF
--- a/core/data/src/main/kotlin/com/divinelink/core/data/jellyseerr/repository/JellyseerrRepository.kt
+++ b/core/data/src/main/kotlin/com/divinelink/core/data/jellyseerr/repository/JellyseerrRepository.kt
@@ -4,6 +4,8 @@ import com.divinelink.core.model.jellyseerr.JellyseerrAccountDetails
 import com.divinelink.core.model.jellyseerr.JellyseerrLoginData
 import com.divinelink.core.model.jellyseerr.media.JellyseerrMediaInfo
 import com.divinelink.core.model.jellyseerr.media.JellyseerrRequest
+import com.divinelink.core.model.jellyseerr.radarr.RadarrInstance
+import com.divinelink.core.model.jellyseerr.radarr.SonarrInstance
 import com.divinelink.core.model.jellyseerr.request.MediaRequestResult
 import com.divinelink.core.network.Resource
 import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaBodyApi
@@ -41,4 +43,8 @@ interface JellyseerrRepository {
   suspend fun getMovieDetails(mediaId: Int): Flow<JellyseerrMediaInfo?>
 
   suspend fun getTvDetails(mediaId: Int): Flow<JellyseerrMediaInfo?>
+
+  suspend fun getRadarrInstances(): Result<List<RadarrInstance>>
+
+  suspend fun getSonarrInstances(): Result<List<SonarrInstance>>
 }

--- a/core/data/src/main/kotlin/com/divinelink/core/data/jellyseerr/repository/ProdJellyseerrRepository.kt
+++ b/core/data/src/main/kotlin/com/divinelink/core/data/jellyseerr/repository/ProdJellyseerrRepository.kt
@@ -11,10 +11,14 @@ import com.divinelink.core.model.jellyseerr.JellyseerrAccountDetails
 import com.divinelink.core.model.jellyseerr.JellyseerrLoginData
 import com.divinelink.core.model.jellyseerr.media.JellyseerrMediaInfo
 import com.divinelink.core.model.jellyseerr.media.JellyseerrRequest
+import com.divinelink.core.model.jellyseerr.radarr.RadarrInstance
+import com.divinelink.core.model.jellyseerr.radarr.SonarrInstance
 import com.divinelink.core.model.jellyseerr.request.MediaRequestResult
 import com.divinelink.core.network.Resource
 import com.divinelink.core.network.jellyseerr.mapper.map
 import com.divinelink.core.network.jellyseerr.mapper.movie.map
+import com.divinelink.core.network.jellyseerr.mapper.radarr.map
+import com.divinelink.core.network.jellyseerr.mapper.sonarr.map
 import com.divinelink.core.network.jellyseerr.mapper.tv.map
 import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaBodyApi
 import com.divinelink.core.network.jellyseerr.service.JellyseerrService
@@ -113,4 +117,12 @@ class ProdJellyseerrRepository(
   override suspend fun getTvDetails(mediaId: Int): Flow<JellyseerrMediaInfo?> = service
     .getTvDetails(mediaId)
     .map { it.getOrNull()?.mediaInfo?.map() }
+
+  override suspend fun getRadarrInstances(): Result<List<RadarrInstance>> = service
+    .getRadarrInstances()
+    .map { it.map() }
+
+  override suspend fun getSonarrInstances(): Result<List<SonarrInstance>> = service
+    .getSonarrInstances()
+    .map { it.map() }
 }

--- a/core/data/src/test/kotlin/com/divinelink/core/data/jellyseerr/ProdJellyseerrRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/divinelink/core/data/jellyseerr/ProdJellyseerrRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.divinelink.core.data.jellyseerr
 
 import app.cash.turbine.test
+import com.divinelink.core.commons.domain.data
 import com.divinelink.core.data.jellyseerr.repository.JellyseerrRepository
 import com.divinelink.core.data.jellyseerr.repository.ProdJellyseerrRepository
 import com.divinelink.core.database.Database
@@ -10,9 +11,12 @@ import com.divinelink.core.fixtures.core.network.jellyseerr.model.movie.MovieInf
 import com.divinelink.core.fixtures.model.jellyseerr.JellyseerrAccountDetailsFactory
 import com.divinelink.core.fixtures.model.jellyseerr.media.JellyseerrMediaInfoFactory
 import com.divinelink.core.fixtures.model.jellyseerr.media.JellyseerrRequestFactory
+import com.divinelink.core.fixtures.model.jellyseerr.radarr.RadarrInstanceFactory
 import com.divinelink.core.fixtures.model.jellyseerr.request.JellyseerrMediaRequestResponseFactory
+import com.divinelink.core.fixtures.model.jellyseerr.sonarr.SonarrInstanceFactory
 import com.divinelink.core.model.Password
 import com.divinelink.core.model.Username
+import com.divinelink.core.model.exception.AppException
 import com.divinelink.core.model.exception.MissingJellyseerrHostAddressException
 import com.divinelink.core.model.jellyseerr.JellyseerrAuthMethod
 import com.divinelink.core.model.jellyseerr.JellyseerrLoginData
@@ -28,8 +32,12 @@ import com.divinelink.core.network.jellyseerr.model.tv.TvSeasonResponse
 import com.divinelink.core.testing.MainDispatcherRule
 import com.divinelink.core.testing.database.TestDatabaseFactory
 import com.divinelink.core.testing.factories.api.jellyseerr.JellyseerrRequestMediaBodyApiFactory
+import com.divinelink.core.testing.factories.api.jellyseerr.response.radarr.RadarrInstanceResponseFactory
+import com.divinelink.core.testing.factories.api.jellyseerr.response.sonarr.SonarrInstanceResponseFactory
 import com.divinelink.core.testing.service.TestJellyseerrService
 import com.google.common.truth.Truth.assertThat
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -420,6 +428,46 @@ class ProdJellyseerrRepositoryTest {
     ).test {
       assertThat(awaitItem()).isEqualTo(Resource.Loading(null))
       assertThat(awaitItem()).isEqualTo(Resource.Success(null))
+    }
+  }
+
+  @Test
+  fun `test get radarr instances with success`() = runTest {
+    remote.mockGetRadarrInstances(
+      Result.success(RadarrInstanceResponseFactory.all),
+    )
+
+    repository.getRadarrInstances().data shouldBe RadarrInstanceFactory.all
+  }
+
+  @Test
+  fun `test get sonarr instances with success`() = runTest {
+    remote.mockGetSonarrInstances(
+      Result.success(SonarrInstanceResponseFactory.all),
+    )
+
+    repository.getSonarrInstances().data shouldBe SonarrInstanceFactory.all
+  }
+
+  @Test
+  fun `test get radarr instances with failure`() = runTest {
+    remote.mockGetRadarrInstances(
+      Result.failure(Exception()),
+    )
+
+    shouldThrow<Exception> {
+      repository.getRadarrInstances().data
+    }
+  }
+
+  @Test
+  fun `test get sonarr instances with failure`() = runTest {
+    remote.mockGetSonarrInstances(
+      Result.failure(AppException.Unknown()),
+    )
+
+    shouldThrow<AppException.Unknown> {
+      repository.getSonarrInstances().data
     }
   }
 }

--- a/core/fixtures/src/main/kotlin/com/divinelink/core/fixtures/model/jellyseerr/radarr/RadarrInstanceFactory.kt
+++ b/core/fixtures/src/main/kotlin/com/divinelink/core/fixtures/model/jellyseerr/radarr/RadarrInstanceFactory.kt
@@ -1,0 +1,39 @@
+package com.divinelink.core.fixtures.model.jellyseerr.radarr
+
+import com.divinelink.core.model.jellyseerr.radarr.RadarrInstance
+
+object RadarrInstanceFactory {
+
+  val radarr = RadarrInstance(
+    id = 0,
+    name = "Radarr",
+    is4k = false,
+    isDefault = true,
+    activeDirectory = "/data/movies",
+    activeProfileId = 6,
+  )
+
+  val radarr4K = RadarrInstance(
+    id = 1,
+    name = "4K Radarr",
+    is4k = true,
+    isDefault = true,
+    activeDirectory = "/data/movies",
+    activeProfileId = 5,
+  )
+
+  val radarrSecondary = RadarrInstance(
+    id = 2,
+    name = "Secondary Radarr",
+    is4k = false,
+    isDefault = false,
+    activeDirectory = "/data/movies",
+    activeProfileId = 2,
+  )
+
+  val all = listOf(
+    radarr,
+    radarr4K,
+    radarrSecondary,
+  )
+}

--- a/core/fixtures/src/main/kotlin/com/divinelink/core/fixtures/model/jellyseerr/sonarr/SonarrInstanceFactory.kt
+++ b/core/fixtures/src/main/kotlin/com/divinelink/core/fixtures/model/jellyseerr/sonarr/SonarrInstanceFactory.kt
@@ -1,0 +1,29 @@
+package com.divinelink.core.fixtures.model.jellyseerr.sonarr
+
+import com.divinelink.core.model.jellyseerr.radarr.SonarrInstance
+
+object SonarrInstanceFactory {
+
+  val sonarr = SonarrInstance(
+    id = 0,
+    name = "Sonarr",
+    is4k = false,
+    isDefault = true,
+    activeDirectory = "/data/tv",
+    activeProfileId = 6,
+  )
+
+  val sonarr4K = SonarrInstance(
+    id = 1,
+    name = "Sonarr 4K",
+    is4k = true,
+    isDefault = true,
+    activeDirectory = "/data/tv",
+    activeProfileId = 6,
+  )
+
+  val all = listOf(
+    sonarr,
+    sonarr4K,
+  )
+}

--- a/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/radarr/RadarrInstance.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/radarr/RadarrInstance.kt
@@ -1,0 +1,13 @@
+package com.divinelink.core.model.jellyseerr.radarr
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RadarrInstance(
+  val id: Int,
+  val name: String,
+  val is4k: Boolean,
+  val isDefault: Boolean,
+  val activeDirectory: String,
+  val activeProfileId: Int,
+)

--- a/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/radarr/SonarrInstance.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/radarr/SonarrInstance.kt
@@ -1,0 +1,13 @@
+package com.divinelink.core.model.jellyseerr.radarr
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SonarrInstance(
+  val id: Int,
+  val name: String,
+  val is4k: Boolean,
+  val isDefault: Boolean,
+  val activeDirectory: String,
+  val activeProfileId: Int,
+)

--- a/core/network/src/main/kotlin/com/divinelink/core/network/client/KtorClient.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/client/KtorClient.kt
@@ -102,12 +102,11 @@ fun ktorClient(engine: HttpClientEngine): HttpClient = HttpClient(engine) {
   }
 }
 
-@OptIn(InternalSerializationApi::class)
 suspend inline fun <reified T : Any> HttpClient.get(url: String): T {
   try {
     val json = this.get(url).bodyAsText()
 
-    return localJson.decodeFromString(T::class.serializer(), json)
+    return localJson.decodeFromString<T>(json)
   } catch (e: Exception) {
     Timber.e("${e.message}")
     throw e

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/mapper/radarr/RadarrInstanceResponseMapper.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/mapper/radarr/RadarrInstanceResponseMapper.kt
@@ -1,0 +1,17 @@
+package com.divinelink.core.network.jellyseerr.mapper.radarr
+
+import com.divinelink.core.model.jellyseerr.radarr.RadarrInstance
+import com.divinelink.core.network.jellyseerr.model.radarr.RadarrInstanceResponse
+
+fun List<RadarrInstanceResponse>.map() = this.map {
+  it.map()
+}
+
+fun RadarrInstanceResponse.map() = RadarrInstance(
+  id = id,
+  name = name,
+  is4k = is4k,
+  isDefault = isDefault,
+  activeDirectory = activeDirectory,
+  activeProfileId = activeProfileId,
+)

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/mapper/sonarr/SonarrInstanceResponseMapper.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/mapper/sonarr/SonarrInstanceResponseMapper.kt
@@ -1,0 +1,17 @@
+package com.divinelink.core.network.jellyseerr.mapper.sonarr
+
+import com.divinelink.core.model.jellyseerr.radarr.SonarrInstance
+import com.divinelink.core.network.jellyseerr.model.radarr.SonarrInstanceResponse
+
+fun List<SonarrInstanceResponse>.map() = this.map {
+  it.map()
+}
+
+fun SonarrInstanceResponse.map() = SonarrInstance(
+  id = id,
+  name = name,
+  is4k = is4k,
+  isDefault = isDefault,
+  activeDirectory = activeDirectory,
+  activeProfileId = activeProfileId,
+)

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/model/radarr/RadarrInstanceResponse.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/model/radarr/RadarrInstanceResponse.kt
@@ -1,0 +1,13 @@
+package com.divinelink.core.network.jellyseerr.model.radarr
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RadarrInstanceResponse(
+  val id: Int,
+  val name: String,
+  val is4k: Boolean,
+  val isDefault: Boolean,
+  val activeDirectory: String,
+  val activeProfileId: Int,
+)

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/model/radarr/SonarrInstanceResponse.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/model/radarr/SonarrInstanceResponse.kt
@@ -1,0 +1,17 @@
+package com.divinelink.core.network.jellyseerr.model.radarr
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SonarrInstanceResponse(
+  val id: Int,
+  val name: String,
+  val is4k: Boolean,
+  val isDefault: Boolean,
+  val activeDirectory: String,
+  val activeProfileId: Int,
+  val activeAnimeProfileId: Int? = null,
+  val activeAnimeDirectory: String? = null,
+  val activeLanguageProfileId: Int? = null,
+  val activeAnimeLanguageProfileId: Int? = null,
+)

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/service/JellyseerrService.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/service/JellyseerrService.kt
@@ -6,6 +6,8 @@ import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaBodyAp
 import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaResponse
 import com.divinelink.core.network.jellyseerr.model.MediaInfoRequestResponse
 import com.divinelink.core.network.jellyseerr.model.movie.JellyseerrMovieDetailsResponse
+import com.divinelink.core.network.jellyseerr.model.radarr.RadarrInstanceResponse
+import com.divinelink.core.network.jellyseerr.model.radarr.SonarrInstanceResponse
 import com.divinelink.core.network.jellyseerr.model.tv.JellyseerrTvDetailsResponse
 import kotlinx.coroutines.flow.Flow
 
@@ -34,4 +36,8 @@ interface JellyseerrService {
   suspend fun getMovieDetails(mediaId: Int): Flow<Result<JellyseerrMovieDetailsResponse>>
 
   suspend fun getTvDetails(mediaId: Int): Flow<Result<JellyseerrTvDetailsResponse>>
+
+  suspend fun getRadarrInstances(): Result<List<RadarrInstanceResponse>>
+
+  suspend fun getSonarrInstances(): Result<List<SonarrInstanceResponse>>
 }

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/service/ProdJellyseerrService.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/service/ProdJellyseerrService.kt
@@ -10,6 +10,8 @@ import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaBodyAp
 import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaResponse
 import com.divinelink.core.network.jellyseerr.model.MediaInfoRequestResponse
 import com.divinelink.core.network.jellyseerr.model.movie.JellyseerrMovieDetailsResponse
+import com.divinelink.core.network.jellyseerr.model.radarr.RadarrInstanceResponse
+import com.divinelink.core.network.jellyseerr.model.radarr.SonarrInstanceResponse
 import com.divinelink.core.network.jellyseerr.model.tv.JellyseerrTvDetailsResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -159,4 +161,26 @@ class ProdJellyseerrService(private val restClient: JellyseerrRestClient) : Jell
       }
       emit(result)
     }
+
+  override suspend fun getRadarrInstances(): Result<List<RadarrInstanceResponse>> = runCatching {
+    val hostAddress = restClient.hostAddress() ?: return Result.failure(
+      MissingJellyseerrHostAddressException(),
+    )
+
+    return runCatching {
+      val url = "$hostAddress/api/v1/service/radarr"
+      restClient.get<List<RadarrInstanceResponse>>(url = url)
+    }
+  }
+
+  override suspend fun getSonarrInstances(): Result<List<SonarrInstanceResponse>> = runCatching {
+    val hostAddress = restClient.hostAddress() ?: return Result.failure(
+      MissingJellyseerrHostAddressException(),
+    )
+
+    return runCatching {
+      val url = "$hostAddress/api/v1/service/sonarr"
+      restClient.get<List<SonarrInstanceResponse>>(url = url)
+    }
+  }
 }

--- a/core/network/src/test/kotlin/com/divinelink/core/network/jellyseerr/service/ProdJellyseerrServiceTest.kt
+++ b/core/network/src/test/kotlin/com/divinelink/core/network/jellyseerr/service/ProdJellyseerrServiceTest.kt
@@ -1,0 +1,94 @@
+package com.divinelink.core.network.jellyseerr.service
+
+import com.divinelink.core.commons.domain.data
+import com.divinelink.core.model.exception.MissingJellyseerrHostAddressException
+import com.divinelink.core.network.jellyseerr.model.radarr.RadarrInstanceResponse
+import com.divinelink.core.testing.factories.api.jellyseerr.response.radarr.RadarrInstanceResponseFactory
+import com.divinelink.core.testing.factories.api.jellyseerr.response.sonarr.SonarrInstanceResponseFactory
+import com.divinelink.core.testing.factories.json.jellyseerr.radarr.RadarrInstanceResponseJson
+import com.divinelink.core.testing.factories.json.jellyseerr.sonarr.SonarrInstanceResponseJson
+import com.divinelink.core.testing.network.TestJellyseerrClient
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class ProdJellyseerrServiceTest {
+
+  private lateinit var service: ProdJellyseerrService
+  private lateinit var restClient: TestJellyseerrClient
+
+  @BeforeTest
+  fun setup() {
+    restClient = TestJellyseerrClient()
+  }
+
+  @Test
+  fun `test getRadarrInstances without host address`() = runTest {
+    restClient.mockGetResponse<List<RadarrInstanceResponse>>(
+      url = "",
+      json = RadarrInstanceResponseJson.success,
+    )
+
+    service = ProdJellyseerrService(
+      restClient = restClient.client,
+    )
+
+    val exception = shouldThrow<MissingJellyseerrHostAddressException> {
+      service.getRadarrInstances().data
+    }
+
+    exception shouldBe MissingJellyseerrHostAddressException()
+  }
+
+  @Test
+  fun `test getRadarrInstances with success`() = runTest {
+    restClient.withAddress("http://localhost:5055")
+
+    restClient.mockGetResponse<List<RadarrInstanceResponse>>(
+      url = "",
+      json = RadarrInstanceResponseJson.success,
+    )
+
+    service = ProdJellyseerrService(
+      restClient = restClient.client,
+    )
+
+    service.getRadarrInstances().data shouldBe RadarrInstanceResponseFactory.all
+  }
+
+  @Test
+  fun `test getSonarrInstances without host address`() = runTest {
+    restClient.mockGetResponse<List<RadarrInstanceResponse>>(
+      url = "",
+      json = SonarrInstanceResponseJson.success,
+    )
+
+    service = ProdJellyseerrService(
+      restClient = restClient.client,
+    )
+
+    val exception = shouldThrow<MissingJellyseerrHostAddressException> {
+      service.getSonarrInstances().data
+    }
+
+    exception shouldBe MissingJellyseerrHostAddressException()
+  }
+
+  @Test
+  fun `test getSonarrInstances with success`() = runTest {
+    restClient.withAddress("http://localhost:5055")
+
+    restClient.mockGetResponse<List<RadarrInstanceResponse>>(
+      url = "",
+      json = SonarrInstanceResponseJson.success,
+    )
+
+    service = ProdJellyseerrService(
+      restClient = restClient.client,
+    )
+
+    service.getSonarrInstances().data shouldBe SonarrInstanceResponseFactory.all
+  }
+}

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/api/jellyseerr/response/radarr/RadarrInstanceResponseFactory.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/api/jellyseerr/response/radarr/RadarrInstanceResponseFactory.kt
@@ -1,0 +1,39 @@
+package com.divinelink.core.testing.factories.api.jellyseerr.response.radarr
+
+import com.divinelink.core.network.jellyseerr.model.radarr.RadarrInstanceResponse
+
+object RadarrInstanceResponseFactory {
+
+  val radarr = RadarrInstanceResponse(
+    id = 0,
+    name = "Radarr",
+    is4k = false,
+    isDefault = true,
+    activeDirectory = "/data/movies",
+    activeProfileId = 6,
+  )
+
+  val radarr4K = RadarrInstanceResponse(
+    id = 1,
+    name = "4K Radarr",
+    is4k = true,
+    isDefault = true,
+    activeDirectory = "/data/movies",
+    activeProfileId = 5,
+  )
+
+  val radarrSecondary = RadarrInstanceResponse(
+    id = 2,
+    name = "Secondary Radarr",
+    is4k = false,
+    isDefault = false,
+    activeDirectory = "/data/movies",
+    activeProfileId = 2,
+  )
+
+  val all = listOf(
+    radarr,
+    radarr4K,
+    radarrSecondary,
+  )
+}

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/api/jellyseerr/response/sonarr/SonarrInstanceResponseFactory.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/api/jellyseerr/response/sonarr/SonarrInstanceResponseFactory.kt
@@ -1,0 +1,37 @@
+package com.divinelink.core.testing.factories.api.jellyseerr.response.sonarr
+
+import com.divinelink.core.network.jellyseerr.model.radarr.SonarrInstanceResponse
+
+object SonarrInstanceResponseFactory {
+
+  val sonarr = SonarrInstanceResponse(
+    id = 0,
+    name = "Sonarr",
+    is4k = false,
+    isDefault = true,
+    activeDirectory = "/data/tv",
+    activeProfileId = 6,
+    activeAnimeProfileId = 6,
+    activeAnimeDirectory = "/data/anime",
+    activeLanguageProfileId = 1,
+    activeAnimeLanguageProfileId = 1,
+  )
+
+  val sonarr4K = SonarrInstanceResponse(
+    id = 1,
+    name = "Sonarr 4K",
+    is4k = true,
+    isDefault = true,
+    activeDirectory = "/data/tv",
+    activeProfileId = 6,
+    activeAnimeProfileId = null,
+    activeAnimeDirectory = null,
+    activeLanguageProfileId = null,
+    activeAnimeLanguageProfileId = null,
+  )
+
+  val all = listOf(
+    sonarr,
+    sonarr4K,
+  )
+}

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/json/jellyseerr/radarr/RadarrInstanceResponseJson.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/json/jellyseerr/radarr/RadarrInstanceResponseJson.kt
@@ -1,0 +1,33 @@
+package com.divinelink.core.testing.factories.json.jellyseerr.radarr
+
+object RadarrInstanceResponseJson {
+
+  val success = """
+    [
+      {
+        "id": 0,
+        "name": "Radarr",
+        "is4k": false,
+        "isDefault": true,
+        "activeDirectory": "/data/movies",
+        "activeProfileId": 6
+      },
+      {
+        "id": 1,
+        "name": "4K Radarr",
+        "is4k": true,
+        "isDefault": true,
+        "activeDirectory": "/data/movies",
+        "activeProfileId": 5
+      },
+      {
+        "id": 2,
+        "name": "Secondary Radarr",
+        "is4k": false,
+        "isDefault": false,
+        "activeDirectory": "/data/movies",
+        "activeProfileId": 2
+      }
+    ]
+  """.trimIndent()
+}

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/json/jellyseerr/sonarr/SonarrInstanceResponseJson.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/factories/json/jellyseerr/sonarr/SonarrInstanceResponseJson.kt
@@ -1,0 +1,31 @@
+package com.divinelink.core.testing.factories.json.jellyseerr.sonarr
+
+object SonarrInstanceResponseJson {
+
+  val success = """
+    [
+      {
+        "id": 0,
+        "name": "Sonarr",
+        "is4k": false,
+        "isDefault": true,
+        "activeDirectory": "/data/tv",
+        "activeProfileId": 6,
+        "activeAnimeProfileId": 6,
+        "activeAnimeDirectory": "/data/anime",
+        "activeLanguageProfileId": 1,
+        "activeAnimeLanguageProfileId": 1,
+        "activeTags": []
+      },
+      {
+        "id": 1,
+        "name": "Sonarr 4K",
+        "is4k": true,
+        "isDefault": true,
+        "activeDirectory": "/data/tv",
+        "activeProfileId": 6,
+        "activeTags": []
+      }
+    ]
+  """.trimIndent()
+}

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/network/TestJellyseerrClient.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/network/TestJellyseerrClient.kt
@@ -1,0 +1,29 @@
+package com.divinelink.core.testing.network
+
+import com.divinelink.core.network.client.JellyseerrRestClient
+import com.divinelink.core.network.client.get
+import com.divinelink.core.testing.storage.FakeEncryptedPreferenceStorage
+import com.divinelink.core.testing.storage.FakePreferenceStorage
+
+class TestJellyseerrClient {
+
+  lateinit var client: JellyseerrRestClient
+  var storage: FakePreferenceStorage = FakePreferenceStorage()
+
+  suspend fun withAddress(address: String) = apply {
+    storage.setJellyseerrAddress(address)
+  }
+
+  suspend inline fun <reified T : Any> mockGetResponse(
+    url: String,
+    json: String,
+  ) {
+    client = JellyseerrRestClient(
+      engine = MockEngine(json),
+      encryptedStorage = FakeEncryptedPreferenceStorage(),
+      storage = storage,
+    )
+
+    client.client.get<T>(url = url)
+  }
+}

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/service/TestJellyseerrService.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/service/TestJellyseerrService.kt
@@ -4,6 +4,8 @@ import com.divinelink.core.network.jellyseerr.model.JellyseerrAccountDetailsResp
 import com.divinelink.core.network.jellyseerr.model.JellyseerrRequestMediaResponse
 import com.divinelink.core.network.jellyseerr.model.MediaInfoRequestResponse
 import com.divinelink.core.network.jellyseerr.model.movie.JellyseerrMovieDetailsResponse
+import com.divinelink.core.network.jellyseerr.model.radarr.RadarrInstanceResponse
+import com.divinelink.core.network.jellyseerr.model.radarr.SonarrInstanceResponse
 import com.divinelink.core.network.jellyseerr.model.tv.JellyseerrTvDetailsResponse
 import com.divinelink.core.network.jellyseerr.service.JellyseerrService
 import kotlinx.coroutines.flow.flowOf
@@ -78,5 +80,13 @@ class TestJellyseerrService {
 
   suspend fun mockGetRequestDetails(response: Result<MediaInfoRequestResponse>) {
     whenever(mock.getRequestDetails(any())).thenReturn(flowOf(response))
+  }
+
+  suspend fun mockGetRadarrInstances(response: Result<List<RadarrInstanceResponse>>) {
+    whenever(mock.getRadarrInstances()).thenReturn(response)
+  }
+
+  suspend fun mockGetSonarrInstances(response: Result<List<SonarrInstanceResponse>>) {
+    whenever(mock.getSonarrInstances()).thenReturn(response)
   }
 }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
@@ -89,7 +89,7 @@ fun DetailsScreen(
     RateModalBottomSheet(
       modifier = Modifier.testTag(TestTags.Details.RATE_DIALOG),
       sheetState = rateBottomSheetState,
-      value = viewState.userDetails?.beautifiedRating,
+      value = viewState.userDetails.beautifiedRating,
       mediaTitle = viewState.mediaDetails?.title ?: "",
       onSubmitRate = {
         openRateBottomSheet = false


### PR DESCRIPTION
### Summary

Implement network and repository layer for fetching default radarr and sonarr instance.