### PR TITLE
Add offline first media item fetching

### DIFF
--- a/core/data/src/main/kotlin/com/divinelink/core/data/details/repository/DetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/divinelink/core/data/details/repository/DetailsRepository.kt
@@ -8,7 +8,9 @@ import com.divinelink.core.model.details.rating.RatingDetails
 import com.divinelink.core.model.details.review.Review
 import com.divinelink.core.model.details.video.Video
 import com.divinelink.core.model.media.MediaItem
+import com.divinelink.core.model.media.MediaReference
 import com.divinelink.core.model.media.MediaType
+import com.divinelink.core.network.Resource
 import com.divinelink.core.network.media.model.MediaRequestApi
 import com.divinelink.core.network.media.model.details.watchlist.AddToWatchlistRequestApi
 import com.divinelink.core.network.media.model.rating.AddRatingRequestApi
@@ -22,6 +24,8 @@ import kotlinx.coroutines.flow.Flow
 interface DetailsRepository {
 
   fun fetchMediaDetails(request: MediaRequestApi): Flow<Result<MediaDetails>>
+
+  fun fetchMediaItem(media: MediaReference): Flow<Resource<MediaItem.Media?>>
 
   fun fetchMediaReviews(request: MediaRequestApi): Flow<Result<List<Review>>>
 

--- a/core/data/src/main/kotlin/com/divinelink/core/data/details/repository/ProdDetailsRepository.kt
+++ b/core/data/src/main/kotlin/com/divinelink/core/data/details/repository/ProdDetailsRepository.kt
@@ -60,7 +60,7 @@ class ProdDetailsRepository(
 ) : DetailsRepository {
 
   override fun fetchMediaDetails(request: MediaRequestApi): Flow<Result<MediaDetails>> = mediaRemote
-    .fetchDetails(request)
+    .fetchDetails(request = request, appendToResponse = true)
     .map { apiResponse ->
       val details = apiResponse.toDomainMedia()
       val mediaItem = details.toMediaItem()

--- a/core/data/src/main/kotlin/com/divinelink/core/data/list/ProdListRepository.kt
+++ b/core/data/src/main/kotlin/com/divinelink/core/data/list/ProdListRepository.kt
@@ -69,7 +69,7 @@ class ProdListRepository(
     saveFetchResult = { remoteData ->
       val details = remoteData.data.map()
 
-      mediaDao.insertMedia(details.media)
+      mediaDao.insertMediaList(details.media)
       listDao.insertListDetails(
         page = page,
         details = details,

--- a/core/database/src/main/kotlin/com/divinelink/core/database/media/dao/MediaDao.kt
+++ b/core/database/src/main/kotlin/com/divinelink/core/database/media/dao/MediaDao.kt
@@ -14,7 +14,7 @@ interface MediaDao {
 
   fun insertMediaEntities(media: List<MediaItemEntity>)
 
-  fun insertMedia(media: List<MediaItem.Media>)
+  fun insertMediaList(media: List<MediaItem.Media>)
 
   fun fetchAllFavorites(): Flow<List<MediaItem.Media>>
 

--- a/core/database/src/main/kotlin/com/divinelink/core/database/media/dao/ProdMediaDao.kt
+++ b/core/database/src/main/kotlin/com/divinelink/core/database/media/dao/ProdMediaDao.kt
@@ -24,7 +24,7 @@ class ProdMediaDao(
     database.mediaItemEntityQueries.insertMediaItem(media.map())
   }
 
-  override fun insertMedia(media: List<MediaItem.Media>) {
+  override fun insertMediaList(media: List<MediaItem.Media>) {
     media.forEach {
       insertMedia(it)
     }

--- a/core/database/src/test/kotlin/com/divinelink/core/database/media/dao/ProdMediaDaoTest.kt
+++ b/core/database/src/test/kotlin/com/divinelink/core/database/media/dao/ProdMediaDaoTest.kt
@@ -49,7 +49,7 @@ class ProdMediaDaoTest {
     dao.fetchMedia(MediaItemFactory.theWire().toStub()) shouldBe null
     dao.fetchMedia(MediaItemFactory.theOffice().toStub()) shouldBe null
 
-    dao.insertMedia(MediaItemFactory.tvAll())
+    dao.insertMediaList(MediaItemFactory.tvAll())
 
     dao.fetchMedia(MediaItemFactory.theWire().toStub()) shouldBe MediaItemFactory.theWire()
     dao.fetchMedia(MediaItemFactory.theOffice().toStub()) shouldBe MediaItemFactory.theOffice()

--- a/core/network/src/main/kotlin/com/divinelink/core/network/media/model/details/DetailsResponseApi.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/media/model/details/DetailsResponseApi.kt
@@ -77,7 +77,7 @@ sealed class DetailsResponseApi {
     val video: Boolean,
     @SerialName("vote_average") override val voteAverage: Double,
     @SerialName("vote_count") override val voteCount: Int,
-    val credits: CreditsApi,
+    val credits: CreditsApi? = null, // TODO credits call should be made separately
     val status: String? = null,
   ) : DetailsResponseApi()
 
@@ -103,7 +103,7 @@ sealed class DetailsResponseApi {
     @SerialName("seasons") val seasons: List<SeasonResponseApi>,
     @SerialName("number_of_seasons") val numberOfSeasons: Int,
     @SerialName("number_of_episodes") val numberOfEpisodes: Int,
-    @SerialName("external_ids") val externalIds: ExternalIdsApi,
+    @SerialName("external_ids") val externalIds: ExternalIdsApi? = null,
     @SerialName("last_air_date") val lastAirDate: String? = null,
     @SerialName("next_episode_to_air") val nextEpisodeToAir: NextEpisodeToAirResponse? = null,
     @SerialName("production_companies") override val companies: List<ProductionCompany>,
@@ -129,8 +129,8 @@ private fun DetailsResponseApi.Movie.toDomainMovie(): MediaDetails = Movie(
   tagline = this.tagline.takeIf { it.isNotBlank() },
   overview = this.overview,
   genres = this.genres.map { it.name }.takeIf { it.isNotEmpty() },
-  creators = this.credits.crew.map(),
-  cast = this.credits.cast.toActors(),
+  creators = this.credits?.crew?.map(),
+  cast = this.credits?.cast?.toActors() ?: emptyList(),
   runtime = this.runtime.toHourMinuteFormat(),
   isFavorite = false,
   imdbId = this.imdbId,
@@ -174,7 +174,7 @@ private fun DetailsResponseApi.TV.toDomainTVShow(): MediaDetails = TV(
   numberOfSeasons = this.numberOfSeasons,
   creators = this.createdBy.map(),
   seasons = this.seasons.map(),
-  imdbId = this.externalIds.imdbId,
+  imdbId = this.externalIds?.imdbId,
   popularity = popularity,
   information = MediaDetailsInformation.TV(
     originalTitle = this.originalName,

--- a/core/network/src/main/kotlin/com/divinelink/core/network/media/service/MediaService.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/media/service/MediaService.kt
@@ -30,7 +30,10 @@ interface MediaService {
   @Deprecated("Use fetchMultiInfo instead")
   fun fetchSearchMovies(request: SearchRequestApi): Flow<SearchResponseApi>
 
-  fun fetchDetails(request: MediaRequestApi): Flow<DetailsResponseApi>
+  fun fetchDetails(
+    request: MediaRequestApi,
+    appendToResponse: Boolean,
+  ): Flow<DetailsResponseApi>
 
   fun fetchReviews(request: MediaRequestApi): Flow<ReviewsResponseApi>
 

--- a/core/network/src/main/kotlin/com/divinelink/core/network/media/service/ProdMediaService.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/media/service/ProdMediaService.kt
@@ -71,8 +71,15 @@ class ProdMediaService(private val restClient: TMDbClient) : MediaService {
     emit(response)
   }
 
-  override fun fetchDetails(request: MediaRequestApi): Flow<DetailsResponseApi> = flow {
-    val url = buildFetchDetailsUrl(media = request.mediaType, id = request.id)
+  override fun fetchDetails(
+    request: MediaRequestApi,
+    appendToResponse: Boolean,
+  ): Flow<DetailsResponseApi> = flow {
+    val url = buildFetchDetailsUrl(
+      media = request.mediaType,
+      id = request.id,
+      appendToResponse = appendToResponse,
+    )
 
     val response = restClient.get<DetailsResponseApi>(url = url)
 

--- a/core/network/src/main/kotlin/com/divinelink/core/network/media/util/BuildUrl.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/media/util/BuildUrl.kt
@@ -9,6 +9,7 @@ import io.ktor.http.encodedPath
 fun buildFetchDetailsUrl(
   id: Int,
   media: MediaType,
+  appendToResponse: Boolean,
 ): String = buildUrl {
   protocol = URLProtocol.HTTPS
   host = Routes.TMDb.HOST
@@ -16,11 +17,13 @@ fun buildFetchDetailsUrl(
 
   parameters.apply {
     append("language", "en-US")
-    when (media) {
-      MediaType.MOVIE -> append("append_to_response", "credits")
-      MediaType.TV -> append("append_to_response", "external_ids")
-      else -> {
-        // Do nothing
+    if (appendToResponse) {
+      when (media) {
+        MediaType.MOVIE -> append("append_to_response", "credits")
+        MediaType.TV -> append("append_to_response", "external_ids")
+        else -> {
+          // Do nothing
+        }
       }
     }
   }

--- a/core/network/src/test/kotlin/com/divinelink/core/network/media/util/BuildUrlTest.kt
+++ b/core/network/src/test/kotlin/com/divinelink/core/network/media/util/BuildUrlTest.kt
@@ -11,6 +11,7 @@ class BuildUrlTest {
     val url = buildFetchDetailsUrl(
       id = 1234,
       media = MediaType.TV,
+      appendToResponse = true,
     )
 
     assertThat(url).isEqualTo(
@@ -19,14 +20,41 @@ class BuildUrlTest {
   }
 
   @Test
+  fun `test buildFetchDetailsUrl for TV with append to response false`() {
+    val url = buildFetchDetailsUrl(
+      id = 1234,
+      media = MediaType.TV,
+      appendToResponse = false,
+    )
+
+    assertThat(url).isEqualTo(
+      "https://api.themoviedb.org/3/tv/1234?language=en-US",
+    )
+  }
+
+  @Test
   fun `test buildFetchDetailsUrl for MOVIE`() {
     val url = buildFetchDetailsUrl(
       id = 1234,
       media = MediaType.MOVIE,
+      appendToResponse = true,
     )
 
     assertThat(url).isEqualTo(
       "https://api.themoviedb.org/3/movie/1234?language=en-US&append_to_response=credits",
+    )
+  }
+
+  @Test
+  fun `test buildFetchDetailsUrl for MOVIE with append to response false`() {
+    val url = buildFetchDetailsUrl(
+      id = 1234,
+      media = MediaType.MOVIE,
+      appendToResponse = false,
+    )
+
+    assertThat(url).isEqualTo(
+      "https://api.themoviedb.org/3/movie/1234?language=en-US",
     )
   }
 

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/dao/TestMediaDao.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/dao/TestMediaDao.kt
@@ -4,6 +4,7 @@ import com.divinelink.core.database.media.dao.MediaDao
 import com.divinelink.core.model.media.MediaItem
 import com.divinelink.core.model.media.MediaType
 import kotlinx.coroutines.flow.Flow
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -38,6 +39,21 @@ class TestMediaDao {
     ).thenReturn(
       result,
     )
+  }
+
+  fun mockFetchMedia(mediaItem: MediaItem.Media?) {
+    whenever(mock.fetchMedia(any())).thenReturn(mediaItem)
+  }
+
+  fun mockFetchMediaWithInsert() {
+    var storedItem: MediaItem.Media? = null
+
+    whenever(mock.insertMedia(any())).thenAnswer { invocation ->
+      storedItem = invocation.getArgument(0)
+      Unit
+    }
+
+    whenever(mock.fetchMedia(any())).thenAnswer { storedItem }
   }
 
   fun verifyInsertFavoriteMovie(id: Int) {

--- a/core/testing/src/main/kotlin/com/divinelink/core/testing/service/TestMediaService.kt
+++ b/core/testing/src/main/kotlin/com/divinelink/core/testing/service/TestMediaService.kt
@@ -21,6 +21,7 @@ import com.divinelink.core.network.media.service.MediaService
 import kotlinx.coroutines.flow.Flow
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 class TestMediaService {
@@ -49,12 +50,13 @@ class TestMediaService {
     )
   }
 
-  fun mockFetchMovieDetails(
+  fun mockFetchDetails(
     request: MediaRequestApi,
     response: Flow<DetailsResponseApi>,
+    appendToResponse: Boolean = true,
   ) {
     whenever(
-      mock.fetchDetails(request),
+      mock.fetchDetails(request = request, appendToResponse = appendToResponse),
     ).thenReturn(
       response,
     )
@@ -162,5 +164,9 @@ class TestMediaService {
     ).thenReturn(
       response,
     )
+  }
+
+  fun verifyNoInteractions() {
+    verifyNoInteractions(mock)
   }
 }


### PR DESCRIPTION
### Summary

Adds offline first logic for fetching media item. 

This will help throttle api requests on our jellyseerr requests feature.