### PR TITLE
[Jellyseerr] Add permission check on edit request

### DIFF
--- a/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/permission/ProfilePermissionExtensions.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/permission/ProfilePermissionExtensions.kt
@@ -3,13 +3,11 @@ package com.divinelink.core.model.jellyseerr.permission
 fun List<ProfilePermission>.canPerform(permission: ProfilePermission): Boolean = isAdmin ||
   contains(permission)
 
-fun List<ProfilePermission>.canManageRequests() = isAdmin || canPerform(
-  ProfilePermission.MANAGE_REQUESTS,
-)
+val List<ProfilePermission>.canManageRequests
+  get() = isAdmin || canPerform(ProfilePermission.MANAGE_REQUESTS)
 
-fun List<ProfilePermission>.canRequestAdvanced() = isAdmin ||
-  canPerform(ProfilePermission.MANAGE_REQUESTS) ||
-  canPerform(ProfilePermission.REQUEST_ADVANCED)
+val List<ProfilePermission>.canRequestAdvanced
+  get() = isAdmin || canManageRequests || canPerform(ProfilePermission.REQUEST_ADVANCED)
 
 fun List<ProfilePermission>.canRequest(isTV: Boolean) = isAdmin ||
   contains(ProfilePermission.REQUEST) ||

--- a/core/model/src/test/kotlin/com/divinelink/core/model/jellyseerr/permission/ProfilePermissionExtensionsTest.kt
+++ b/core/model/src/test/kotlin/com/divinelink/core/model/jellyseerr/permission/ProfilePermissionExtensionsTest.kt
@@ -26,18 +26,18 @@ class ProfilePermissionExtensionsTest {
 
   @Test
   fun `test canManageRequests as admin is true`() {
-    listOf(ProfilePermission.ADMIN).canManageRequests() shouldBe true
+    listOf(ProfilePermission.ADMIN).canManageRequests shouldBe true
   }
 
   @Test
   fun `test canManageRequests with MANAGE_REQUESTS permission is true`() {
-    listOf(ProfilePermission.MANAGE_REQUESTS).canManageRequests() shouldBe true
+    listOf(ProfilePermission.MANAGE_REQUESTS).canManageRequests shouldBe true
   }
 
   @Test
   fun `test canManageRequests without permission is false`() {
-    emptyList<ProfilePermission>().canManageRequests() shouldBe false
-    listOf(ProfilePermission.REQUEST).canManageRequests() shouldBe false
+    emptyList<ProfilePermission>().canManageRequests shouldBe false
+    listOf(ProfilePermission.REQUEST).canManageRequests shouldBe false
   }
 
   @Test
@@ -144,22 +144,22 @@ class ProfilePermissionExtensionsTest {
 
   @Test
   fun `test canRequestAdvanced without permission is false`() {
-    emptyList<ProfilePermission>().canRequestAdvanced() shouldBe false
+    emptyList<ProfilePermission>().canRequestAdvanced shouldBe false
   }
 
   @Test
   fun `test canRequestAdvanced as admin is true`() {
-    listOf(ProfilePermission.ADMIN).canRequestAdvanced() shouldBe true
+    listOf(ProfilePermission.ADMIN).canRequestAdvanced shouldBe true
   }
 
   @Test
   fun `test canRequestAdvanced with REQUEST_ADVANCED is true`() {
-    listOf(ProfilePermission.REQUEST_ADVANCED).canRequestAdvanced() shouldBe true
+    listOf(ProfilePermission.REQUEST_ADVANCED).canRequestAdvanced shouldBe true
   }
 
   @Test
   fun `test canRequestAdvanced with MANAGE_REQUESTS is true`() {
-    listOf(ProfilePermission.MANAGE_REQUESTS).canRequestAdvanced() shouldBe true
+    listOf(ProfilePermission.MANAGE_REQUESTS).canRequestAdvanced shouldBe true
   }
 
   @Test
@@ -185,7 +185,7 @@ class ProfilePermissionExtensionsTest {
     permissions.canRequest(isTV = false) shouldBe true
     permissions.canRequest4K(isTV = true) shouldBe true
     permissions.canRequest4K(isTV = false) shouldBe true
-    permissions.canManageRequests() shouldBe true
+    permissions.canManageRequests shouldBe true
     permissions.isAdmin shouldBe true
   }
 
@@ -201,7 +201,7 @@ class ProfilePermissionExtensionsTest {
     permissions.canRequest(isTV = false) shouldBe false
     permissions.canRequest4K(isTV = true) shouldBe false
     permissions.canRequest4K(isTV = false) shouldBe true
-    permissions.canManageRequests() shouldBe true
+    permissions.canManageRequests shouldBe true
     permissions.isAdmin shouldBe false
   }
 
@@ -213,7 +213,7 @@ class ProfilePermissionExtensionsTest {
     permissions.canRequest(isTV = false) shouldBe false
     permissions.canRequest4K(isTV = true) shouldBe false
     permissions.canRequest4K(isTV = false) shouldBe false
-    permissions.canManageRequests() shouldBe false
+    permissions.canManageRequests shouldBe false
     permissions.isAdmin shouldBe false
     permissions.canPerform(ProfilePermission.REQUEST) shouldBe false
   }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsContent.kt
@@ -160,7 +160,7 @@ fun DetailsContent(
       isLoading = viewState.isLoading,
       mediaType = viewState.mediaType,
       onDeleteMedia = onDeleteMedia,
-      showAdvancedOptions = viewState.permissions.canManageRequests(),
+      showAdvancedOptions = viewState.permissions.canManageRequests,
     )
   }
 

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -831,7 +831,7 @@ class DetailsViewModel(
 
     withManageTv(
       canManage = seasons.any { it.isAvailable() } || status != JellyseerrStatus.Media.UNKNOWN,
-      withPermission = permissions.canManageRequests(),
+      withPermission = permissions.canManageRequests,
       requests = info?.requests ?: emptyList(),
     )
 
@@ -850,7 +850,7 @@ class DetailsViewModel(
      */
     withManageMovie(
       canManage = info.status != JellyseerrStatus.Media.UNKNOWN,
-      withPermission = permissions.canManageRequests() || info.requests.isNotEmpty(),
+      withPermission = permissions.canManageRequests || info.requests.isNotEmpty(),
     )
 
     withRequest(

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
@@ -12,9 +12,9 @@ import com.divinelink.core.model.details.TV
 import com.divinelink.core.model.details.media.DetailsForms
 import com.divinelink.core.model.details.rating.RatingSource
 import com.divinelink.core.model.details.video.Video
+import com.divinelink.core.model.jellyseerr.media.JellyseerrMediaInfo
 import com.divinelink.core.model.jellyseerr.permission.ProfilePermission
 import com.divinelink.core.model.jellyseerr.permission.canManageRequests
-import com.divinelink.core.model.jellyseerr.media.JellyseerrMediaInfo
 import com.divinelink.core.model.media.MediaItem
 import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.model.tab.Tab

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/ui/DetailsViewState.kt
@@ -73,6 +73,5 @@ data class DetailsViewState(
   }
 
   val canManageRequests
-    get() = permissions.canManageRequests() ||
-      jellyseerrMediaInfo?.requests?.isNotEmpty() == true
+    get() = permissions.canManageRequests || jellyseerrMediaInfo?.requests?.isNotEmpty() == true
 }

--- a/feature/details/src/main/kotlin/com/divinelink/feature/details/media/usecase/GetMediaDetailsUseCase.kt
+++ b/feature/details/src/main/kotlin/com/divinelink/feature/details/media/usecase/GetMediaDetailsUseCase.kt
@@ -18,8 +18,8 @@ import com.divinelink.core.model.details.MediaDetails
 import com.divinelink.core.model.details.Movie
 import com.divinelink.core.model.details.rating.RatingDetails
 import com.divinelink.core.model.details.rating.RatingSource
-import com.divinelink.core.model.jellyseerr.permission.canManageRequests
 import com.divinelink.core.model.jellyseerr.media.JellyseerrMediaInfo
+import com.divinelink.core.model.jellyseerr.permission.canManageRequests
 import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.model.tab.MovieTab
 import com.divinelink.core.model.tab.TvTab
@@ -274,7 +274,7 @@ open class GetMediaDetailsUseCase(
   ) {
     val permissions = authRepository.profilePermissions.first()
 
-    val filteredResults = if (permissions.canManageRequests()) {
+    val filteredResults = if (permissions.canManageRequests) {
       result
     } else {
       val currentUserId = authRepository.selectedJellyseerrProfile.first()?.id

--- a/feature/request-media/src/main/kotlin/com/divinelink/feature/request/media/RequestMediaViewModel.kt
+++ b/feature/request-media/src/main/kotlin/com/divinelink/feature/request/media/RequestMediaViewModel.kt
@@ -97,7 +97,7 @@ class RequestMediaViewModel(
     }
 
     viewModelScope.launch {
-      if (uiState.value.permissions.canRequestAdvanced()) {
+      if (uiState.value.permissions.canRequestAdvanced) {
         getServerInstancesUseCase(uiState.value.media.mediaType).fold(
           onSuccess = { instances ->
             _uiState.update { uiState ->

--- a/feature/requests/src/main/kotlin/com/divinelink/feature/requests/ui/RequestMediaItem.kt
+++ b/feature/requests/src/main/kotlin/com/divinelink/feature/requests/ui/RequestMediaItem.kt
@@ -45,6 +45,7 @@ import com.divinelink.feature.requests.ui.buttons.PendingActionButtons
 fun LazyItemScope.RequestMediaItem(
   modifier: Modifier = Modifier,
   canManageRequest: Boolean,
+  canRequestAdvanced: Boolean,
   item: RequestUiItem,
   onAction: (RequestsAction) -> Unit,
   onClick: (MediaItem.Media) -> Unit,
@@ -152,6 +153,7 @@ fun LazyItemScope.RequestMediaItem(
             request = item.request,
             enabled = !state.loading,
             onAction = onAction,
+            canRequestAdvanced = canRequestAdvanced,
             canManageRequest = canManageRequest,
           )
 
@@ -201,11 +203,13 @@ fun ActionButtons(
   request: JellyseerrRequest,
   enabled: Boolean,
   canManageRequest: Boolean,
+  canRequestAdvanced: Boolean,
   onAction: (RequestsAction) -> Unit,
 ) {
   when (request.requestStatus) {
     JellyseerrStatus.Request.PENDING -> PendingActionButtons(
-      hasPermission = canManageRequest,
+      canManageRequests = canManageRequest,
+      canRequestAdvanced = canRequestAdvanced,
       onAction = onAction,
       enabled = enabled,
       request = request,

--- a/feature/requests/src/main/kotlin/com/divinelink/feature/requests/ui/RequestsContent.kt
+++ b/feature/requests/src/main/kotlin/com/divinelink/feature/requests/ui/RequestsContent.kt
@@ -29,8 +29,8 @@ import com.divinelink.core.designsystem.theme.LocalBottomNavigationPadding
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.model.DataState
 import com.divinelink.core.model.filter.MediaRequestFilter
-import com.divinelink.core.model.jellyseerr.permission.ProfilePermission
-import com.divinelink.core.model.jellyseerr.permission.canPerform
+import com.divinelink.core.model.jellyseerr.permission.canManageRequests
+import com.divinelink.core.model.jellyseerr.permission.canRequestAdvanced
 import com.divinelink.core.model.media.encodeToString
 import com.divinelink.core.navigation.route.Navigation
 import com.divinelink.core.ui.Previews
@@ -161,7 +161,8 @@ fun RequestsScrollableContent(
               },
               onLongClick = { onNavigate(Navigation.ActionMenuRoute.Media(it.encodeToString())) },
               onAction = action,
-              canManageRequest = state.permissions.canPerform(ProfilePermission.MANAGE_REQUESTS),
+              canManageRequest = state.permissions.canManageRequests(),
+              canRequestAdvanced = state.permissions.canRequestAdvanced(),
             )
           }
 

--- a/feature/requests/src/main/kotlin/com/divinelink/feature/requests/ui/RequestsContent.kt
+++ b/feature/requests/src/main/kotlin/com/divinelink/feature/requests/ui/RequestsContent.kt
@@ -161,8 +161,8 @@ fun RequestsScrollableContent(
               },
               onLongClick = { onNavigate(Navigation.ActionMenuRoute.Media(it.encodeToString())) },
               onAction = action,
-              canManageRequest = state.permissions.canManageRequests(),
-              canRequestAdvanced = state.permissions.canRequestAdvanced(),
+              canManageRequest = state.permissions.canManageRequests,
+              canRequestAdvanced = state.permissions.canRequestAdvanced,
             )
           }
 

--- a/feature/requests/src/main/kotlin/com/divinelink/feature/requests/ui/buttons/PendingActionButtons.kt
+++ b/feature/requests/src/main/kotlin/com/divinelink/feature/requests/ui/buttons/PendingActionButtons.kt
@@ -10,17 +10,18 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.model.jellyseerr.media.JellyseerrRequest
-import com.divinelink.feature.requests.RequestsAction
 import com.divinelink.core.ui.button.action.ActionButton
+import com.divinelink.feature.requests.RequestsAction
 
 @Composable
 fun PendingActionButtons(
   request: JellyseerrRequest,
   enabled: Boolean,
-  hasPermission: Boolean,
+  canManageRequests: Boolean,
+  canRequestAdvanced: Boolean,
   onAction: (RequestsAction) -> Unit,
 ) {
-  if (hasPermission) {
+  if (canManageRequests) {
     Column(
       modifier = Modifier.fillMaxWidth(),
       horizontalAlignment = Alignment.CenterHorizontally,
@@ -51,9 +52,11 @@ fun PendingActionButtons(
       horizontalAlignment = Alignment.CenterHorizontally,
       verticalArrangement = Arrangement.spacedBy(MaterialTheme.dimensions.keyline_4),
     ) {
-      ActionButton.EditRequest(
-        enabled = enabled,
-      ) { onAction(RequestsAction.EditRequest(request)) }
+      if (canRequestAdvanced) {
+        ActionButton.EditRequest(
+          enabled = enabled,
+        ) { onAction(RequestsAction.EditRequest(request)) }
+      }
 
       ActionButton.CancelRequest(
         enabled = enabled,


### PR DESCRIPTION
### Summary

On the requests screen, the `Edit request` button should be displayed only when the user has the `REQUEST_ADVANCED` permission.