### PR TITLE
Fix refresh indicator on lists pull to refresh

### DIFF
--- a/feature/lists/src/main/kotlin/com/divinelink/feature/lists/details/ListDetailsViewModel.kt
+++ b/feature/lists/src/main/kotlin/com/divinelink/feature/lists/details/ListDetailsViewModel.kt
@@ -16,6 +16,7 @@ import com.divinelink.core.navigation.route.Navigation.ListDetailsRoute
 import com.divinelink.core.ui.blankslate.BlankSlateState
 import com.divinelink.core.ui.snackbar.SnackbarMessage
 import com.divinelink.feature.add.to.account.R
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -61,6 +62,10 @@ class ListDetailsViewModel(
     }
 
     viewModelScope.launch {
+      if (isRefreshing) {
+        delay(250)
+      }
+
       fetchListDetailsUseCase.invoke(
         FetchListParameters(
           listId = uiState.value.id,

--- a/feature/lists/src/main/kotlin/com/divinelink/feature/lists/user/ListsViewModel.kt
+++ b/feature/lists/src/main/kotlin/com/divinelink/feature/lists/user/ListsViewModel.kt
@@ -12,6 +12,7 @@ import com.divinelink.core.model.exception.SessionException
 import com.divinelink.core.model.list.ListData
 import com.divinelink.core.ui.blankslate.BlankSlateState
 import com.divinelink.feature.lists.R
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -50,6 +51,10 @@ class ListsViewModel(private val fetchUserListsUseCase: FetchUserListsUseCase) :
       )
     }
     viewModelScope.launch {
+      if (isRefreshing) {
+        delay(250)
+      }
+
       fetchUserListsUseCase(
         UserListsParameters(
           page = if (isRefreshing) 1 else uiState.value.page,

--- a/feature/lists/src/test/kotlin/com/divinelink/feature/lists/details/ListDetailsScreenTest.kt
+++ b/feature/lists/src/test/kotlin/com/divinelink/feature/lists/details/ListDetailsScreenTest.kt
@@ -2,6 +2,8 @@ package com.divinelink.feature.lists.details
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.isDisplayed
+import androidx.compose.ui.test.isNotDisplayed
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithTag
@@ -12,6 +14,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
 import androidx.lifecycle.SavedStateHandle
 import com.divinelink.core.fixtures.model.list.ListDetailsFactory
+import com.divinelink.core.fixtures.model.list.ListItemFactory
 import com.divinelink.core.model.exception.AppException
 import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.model.media.toStub
@@ -128,6 +131,9 @@ class ListDetailsScreenTest : ComposeTest() {
         swipeDown()
       }
 
+      waitUntil {
+        onNodeWithTag(TestTags.Lists.Details.EMPTY_ITEM).isNotDisplayed()
+      }
       onNodeWithTag(TestTags.Lists.Details.EMPTY_ITEM).assertIsNotDisplayed()
 
       onNodeWithText("The Wire").assertIsDisplayed()

--- a/feature/lists/src/test/kotlin/com/divinelink/feature/lists/user/ListsScreenTest.kt
+++ b/feature/lists/src/test/kotlin/com/divinelink/feature/lists/user/ListsScreenTest.kt
@@ -2,6 +2,7 @@ package com.divinelink.feature.lists.user
 
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.isDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
@@ -22,6 +23,7 @@ import com.divinelink.core.testing.usecase.TestFetchUserListsUseCase
 import com.divinelink.core.ui.TestTags
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 
 class ListsScreenTest : ComposeTest() {
@@ -81,7 +83,7 @@ class ListsScreenTest : ComposeTest() {
   }
 
   @Test
-  fun `test refresh list`() {
+  fun `test refresh list`() = runTest {
     fetchUserListsUseCase.mockResponse(
       Result.success(ListItemFactory.page2()),
     )
@@ -108,6 +110,9 @@ class ListsScreenTest : ComposeTest() {
         swipeDown()
       }
 
+      waitUntil {
+        onNodeWithText(ListItemFactory.movies().name).isDisplayed()
+      }
       onNodeWithText(ListItemFactory.movies().name).assertIsDisplayed()
     }
   }


### PR DESCRIPTION
### Summary

Fix loading indicator by adding a small delay between pull to refresh and the actual API call. 