### PR TITLE
Fix discover filters not being unique for each media type

### DIFF
--- a/core/data/src/main/kotlin/com/divinelink/core/data/FilterRepository.kt
+++ b/core/data/src/main/kotlin/com/divinelink/core/data/FilterRepository.kt
@@ -3,35 +3,60 @@ package com.divinelink.core.data
 import com.divinelink.core.model.Genre
 import com.divinelink.core.model.locale.Country
 import com.divinelink.core.model.locale.Language
+import com.divinelink.core.model.media.MediaType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class FilterRepository {
-  private val _selectedGenres = MutableStateFlow<List<Genre>>(emptyList())
-  val selectedGenres: StateFlow<List<Genre>> = _selectedGenres.asStateFlow()
+  private val _selectedGenres = MutableStateFlow<Map<MediaType, List<Genre>>>(
+    mapOf(
+      MediaType.MOVIE to emptyList(),
+      MediaType.TV to emptyList(),
+    ),
+  )
+  val selectedGenres: StateFlow<Map<MediaType, List<Genre>>> = _selectedGenres.asStateFlow()
 
-  private val _selectedLanguage = MutableStateFlow<Language?>(null)
-  val selectedLanguage: StateFlow<Language?> = _selectedLanguage.asStateFlow()
+  private val _selectedLanguage = MutableStateFlow<Map<MediaType, Language?>>(
+    mapOf(
+      MediaType.MOVIE to null,
+      MediaType.TV to null,
+    ),
+  )
+  val selectedLanguage: StateFlow<Map<MediaType, Language?>> = _selectedLanguage.asStateFlow()
 
-  private val _selectedCountry = MutableStateFlow<Country?>(null)
-  val selectedCountry: StateFlow<Country?> = _selectedCountry.asStateFlow()
+  private val _selectedCountry = MutableStateFlow<Map<MediaType, Country?>>(
+    mapOf(
+      MediaType.MOVIE to null,
+      MediaType.TV to null,
+    ),
+  )
+  val selectedCountry: StateFlow<Map<MediaType, Country?>> = _selectedCountry.asStateFlow()
 
-  fun updateSelectedGenres(genres: List<Genre>) {
-    _selectedGenres.value = genres
+  fun updateSelectedGenres(
+    mediaType: MediaType,
+    genres: List<Genre>,
+  ) {
+    _selectedGenres.value += mediaType to genres
   }
 
-  fun updateLanguage(language: Language?) {
-    _selectedLanguage.value = language
+  fun updateLanguage(
+    mediaType: MediaType,
+    language: Language?,
+  ) {
+    _selectedLanguage.value += mediaType to language
   }
 
-  fun updateCountry(country: Country?) {
-    _selectedCountry.value = country
+  fun updateCountry(
+    mediaType: MediaType,
+    country: Country?,
+  ) {
+    _selectedCountry.value += mediaType to country
   }
 
-  fun clear() {
-    _selectedGenres.value = emptyList()
-    _selectedLanguage.value = null
-    _selectedCountry.value = null
+  fun clear(mediaType: MediaType) {
+    _selectedGenres.value += mediaType to emptyList()
+    _selectedLanguage.value += mediaType to null
+    _selectedCountry.value += mediaType to null
   }
 }

--- a/feature/discover/src/main/kotlin/com/divinelink/feature/discover/DiscoverViewModel.kt
+++ b/feature/discover/src/main/kotlin/com/divinelink/feature/discover/DiscoverViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 
@@ -29,6 +30,7 @@ class DiscoverViewModel(
   init {
     filterRepository
       .selectedGenres
+      .map { it[uiState.value.selectedMedia] ?: emptyList() }
       .onEach { genres ->
         _uiState.update { uiState ->
           uiState.copy(
@@ -43,6 +45,7 @@ class DiscoverViewModel(
 
     filterRepository
       .selectedLanguage
+      .map { it[uiState.value.selectedMedia] }
       .onEach { language ->
         _uiState.update { uiState ->
           uiState.copy(
@@ -57,6 +60,7 @@ class DiscoverViewModel(
 
     filterRepository
       .selectedCountry
+      .map { it[uiState.value.selectedMedia] }
       .onEach { country ->
         _uiState.update { uiState ->
           uiState.copy(
@@ -80,7 +84,7 @@ class DiscoverViewModel(
   }
 
   private fun handleClearFilters() {
-    filterRepository.clear()
+    filterRepository.clear(mediaType = _uiState.value.selectedMedia)
     handleDiscoverMedia(reset = true)
   }
 
@@ -210,7 +214,7 @@ class DiscoverViewModel(
 
   override fun onCleared() {
     super.onCleared()
-    filterRepository.clear()
+    filterRepository.clear(mediaType = _uiState.value.selectedMedia)
   }
 
   private fun Map<MediaType, MediaTypeFilters>.updateFilters(


### PR DESCRIPTION
### Summary

Fixes issue where the discover filters we not unique for each media type and filter selection would show incorrect selected filters for each tab. The issue resided on the fact the `FilterRepository` would share the same instance with both tabs, making each tab adhere to the same selected filters. 

We fixed that by making the `FilterRepository` map the selected filters to the current selected media type. 

