### PR TITLE
Fix discover screen to only show distinct media

### DIFF
--- a/core/ui/src/main/kotlin/com/divinelink/core/ui/button/switchview/SwitchViewButton.kt
+++ b/core/ui/src/main/kotlin/com/divinelink/core/ui/button/switchview/SwitchViewButton.kt
@@ -20,8 +20,8 @@ import com.divinelink.core.model.ui.UiPreferences
 import com.divinelink.core.model.ui.ViewMode
 import com.divinelink.core.model.ui.ViewableSection
 import com.divinelink.core.ui.Previews
-import com.divinelink.core.ui.R
 import com.divinelink.core.ui.TestTags
+import com.divinelink.core.ui.UiString
 import com.divinelink.core.ui.composition.LocalUiPreferences
 import com.divinelink.core.ui.composition.PreviewLocalProvider
 import com.divinelink.core.ui.composition.rememberViewModePreferences
@@ -49,7 +49,7 @@ fun SwitchViewButton(
   ) {
     Icon(
       imageVector = icon,
-      contentDescription = stringResource(R.string.core_ui_change_layout_button),
+      contentDescription = stringResource(UiString.core_ui_change_layout_button),
       tint = MaterialTheme.colorScheme.primary,
     )
   }

--- a/feature/discover/src/main/kotlin/com/divinelink/feature/discover/DiscoverForm.kt
+++ b/feature/discover/src/main/kotlin/com/divinelink/feature/discover/DiscoverForm.kt
@@ -18,7 +18,7 @@ sealed interface DiscoverForm<out T : MediaItem.Media> {
     val paginationData: Map<Int, List<MediaItem.Media>>,
     val totalResults: Int,
   ) : DiscoverForm<T> {
-    val media = paginationData.values.flatten()
+    val media = paginationData.values.flatten().distinctBy { it.id }
     val isEmpty: Boolean = media.isEmpty()
   }
 }

--- a/feature/lists/src/main/kotlin/com/divinelink/feature/lists/details/ui/ListDetailsScreen.kt
+++ b/feature/lists/src/main/kotlin/com/divinelink/feature/lists/details/ui/ListDetailsScreen.kt
@@ -43,6 +43,7 @@ import com.divinelink.core.ui.snackbar.SnackbarMessageHandler
 import com.divinelink.feature.lists.details.ListDetailsAction
 import com.divinelink.feature.lists.details.ListDetailsViewModel
 import org.koin.androidx.compose.koinViewModel
+import timber.log.Timber
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable


### PR DESCRIPTION
### Summary

The discover API sometimes may return duplicate items. We need to filter out duplicates in order to avoid crash from similar ids in our lazy grid. 

Additionally, the PR fixes some UI tests.