### PR TITLE
Trim trailing characters on jellyseerr auth fields

### DIFF
--- a/core/data/src/test/kotlin/com/divinelink/core/data/jellyseerr/ProdJellyseerrRepositoryTest.kt
+++ b/core/data/src/test/kotlin/com/divinelink/core/data/jellyseerr/ProdJellyseerrRepositoryTest.kt
@@ -18,6 +18,7 @@ import com.divinelink.core.fixtures.model.jellyseerr.server.radarr.RadarrInstanc
 import com.divinelink.core.fixtures.model.jellyseerr.server.radarr.RadarrInstanceFactory
 import com.divinelink.core.fixtures.model.jellyseerr.server.sonarr.SonarrInstanceDetailsFactory
 import com.divinelink.core.fixtures.model.jellyseerr.server.sonarr.SonarrInstanceFactory
+import com.divinelink.core.model.Address
 import com.divinelink.core.model.Password
 import com.divinelink.core.model.Username
 import com.divinelink.core.model.exception.AppException
@@ -88,9 +89,9 @@ class ProdJellyseerrRepositoryTest {
 
     val result = repository.signInWithJellyfin(
       loginData = JellyseerrLoginData(
-        username = Username("jellyfinUsername"),
+        username = Username.from("jellyfinUsername"),
         password = Password("password"),
-        address = "http://localhost:8096",
+        address = Address.from("http://localhost:8096"),
         authMethod = JellyseerrAuthMethod.JELLYFIN,
       ),
     )
@@ -104,9 +105,9 @@ class ProdJellyseerrRepositoryTest {
 
     val result = repository.signInWithJellyseerr(
       loginData = JellyseerrLoginData(
-        username = Username("jellyseerrUsername"),
+        username = Username.from("jellyseerrUsername"),
         password = Password("password"),
-        address = "http://localhost:8096",
+        address = Address.from("http://localhost:8096"),
         authMethod = JellyseerrAuthMethod.JELLYSEERR,
       ),
     )

--- a/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCase.kt
+++ b/core/domain/src/main/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCase.kt
@@ -29,8 +29,8 @@ class LoginJellyseerrUseCase(
       onSuccess = {
         authRepository.updateJellyseerrCredentials(
           SavedState.JellyseerrCredentials(
-            account = parameters.username.value,
-            address = parameters.address,
+            account = parameters.username.normalized,
+            address = parameters.address.normalized,
             authMethod = parameters.authMethod,
             password = parameters.password.value,
           ),
@@ -38,7 +38,7 @@ class LoginJellyseerrUseCase(
 
         repository.getJellyseerrProfile(
           refresh = true,
-          address = parameters.address,
+          address = parameters.address.value,
         ).collect {
           emit(Result.success(Unit))
         }

--- a/core/domain/src/test/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCaseTest.kt
+++ b/core/domain/src/test/kotlin/com/divinelink/core/domain/jellyseerr/LoginJellyseerrUseCaseTest.kt
@@ -2,6 +2,7 @@ package com.divinelink.core.domain.jellyseerr
 
 import com.divinelink.core.datastore.auth.SavedState
 import com.divinelink.core.fixtures.model.jellyseerr.JellyseerrProfileFactory
+import com.divinelink.core.model.Address
 import com.divinelink.core.model.Password
 import com.divinelink.core.model.Username
 import com.divinelink.core.model.jellyseerr.JellyseerrAuthMethod
@@ -44,9 +45,9 @@ class LoginJellyseerrUseCaseTest {
 
     useCase.invoke(
       JellyseerrLoginData(
-        username = Username("jellyfinUsername"),
+        username = Username.from("jellyfinUsername"),
         password = Password("password"),
-        address = "http://localhost:8096",
+        address = Address.from("http://localhost:8096"),
         authMethod = JellyseerrAuthMethod.JELLYFIN,
       ),
     ).collect {
@@ -81,9 +82,9 @@ class LoginJellyseerrUseCaseTest {
 
     useCase.invoke(
       JellyseerrLoginData(
-        username = Username("jellyseerrUsername"),
+        username = Username.from("jellyseerrUsername"),
         password = Password("password"),
-        address = "http://localhost:8096",
+        address = Address.from("http://localhost:8096"),
         authMethod = JellyseerrAuthMethod.JELLYSEERR,
       ),
     ).collect {
@@ -113,9 +114,9 @@ class LoginJellyseerrUseCaseTest {
 
     useCase.invoke(
       JellyseerrLoginData(
-        username = Username("jellyseerrUsername"),
+        username = Username.from("jellyseerrUsername"),
         password = Password("password"),
-        address = "http://localhost:8096",
+        address = Address.from("http://localhost:8096"),
         authMethod = JellyseerrAuthMethod.JELLYSEERR,
       ),
     ).first()
@@ -136,9 +137,9 @@ class LoginJellyseerrUseCaseTest {
 
     useCase.invoke(
       JellyseerrLoginData(
-        username = Username("jellyseerrUsername"),
+        username = Username.from("jellyseerrUsername"),
         password = Password("password"),
-        address = "http://localhost:8096",
+        address = Address.from("http://localhost:8096"),
         authMethod = JellyseerrAuthMethod.JELLYFIN,
       ),
     ).first()
@@ -158,9 +159,9 @@ class LoginJellyseerrUseCaseTest {
 
     useCase.invoke(
       JellyseerrLoginData(
-        username = Username("jellyseerrUsername"),
+        username = Username.from("jellyseerrUsername"),
         password = Password("password"),
-        address = "http://localhost:8096",
+        address = Address.from("http://localhost:8096"),
         authMethod = JellyseerrAuthMethod.JELLYSEERR,
       ),
     ).collect {
@@ -180,9 +181,9 @@ class LoginJellyseerrUseCaseTest {
 
     useCase.invoke(
       JellyseerrLoginData(
-        username = Username("jellyfinUsername"),
+        username = Username.from("jellyfinUsername"),
         password = Password("password"),
-        address = "http://localhost:8096",
+        address = Address.from("http://localhost:8096"),
         authMethod = JellyseerrAuthMethod.JELLYFIN,
       ),
     ).collect {

--- a/core/model/src/main/kotlin/com/divinelink/core/model/Address.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/Address.kt
@@ -1,0 +1,15 @@
+package com.divinelink.core.model
+
+@JvmInline
+value class Address private constructor(val address: String) {
+  val value
+    get() = address
+
+  val normalized
+    get() = address.trim()
+
+  companion object {
+    fun from(value: String) = Address(value)
+    fun empty() = Address("")
+  }
+}

--- a/core/model/src/main/kotlin/com/divinelink/core/model/Username.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/Username.kt
@@ -1,8 +1,15 @@
 package com.divinelink.core.model
 
 @JvmInline
-value class Username(val value: String) {
+value class Username private constructor(private val username: String) {
+  val value
+    get() = username
+
+  val normalized
+    get() = username.trim()
+
   companion object {
+    fun from(value: String) = Username(value)
     fun empty() = Username("")
   }
 }

--- a/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/JellyseerrLoginData.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/JellyseerrLoginData.kt
@@ -1,24 +1,25 @@
 package com.divinelink.core.model.jellyseerr
 
+import com.divinelink.core.model.Address
 import com.divinelink.core.model.Password
 import com.divinelink.core.model.Username
 
 data class JellyseerrLoginData(
-  val address: String,
+  val address: Address,
   val username: Username,
   val password: Password,
   val authMethod: JellyseerrAuthMethod,
 ) {
   companion object {
     fun empty() = JellyseerrLoginData(
-      address = "",
+      address = Address.empty(),
       username = Username.empty(),
       password = Password.empty(),
       authMethod = JellyseerrAuthMethod.JELLYFIN,
     )
 
     fun prefilled(address: String = "") = JellyseerrLoginData(
-      address = address,
+      address = Address.from(address),
       username = Username.empty(),
       password = Password.empty(),
       authMethod = JellyseerrAuthMethod.JELLYFIN,

--- a/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/JellyseerrState.kt
+++ b/core/model/src/main/kotlin/com/divinelink/core/model/jellyseerr/JellyseerrState.kt
@@ -9,7 +9,7 @@ sealed class JellyseerrState(
   ) : JellyseerrState(
     loginData = loginData,
   ) {
-    val isLoginEnabled = loginData.address.isNotEmpty() &&
+    val isLoginEnabled = loginData.address.value.isNotEmpty() &&
       loginData.username.value.isNotEmpty() &&
       loginData.password.value.isNotEmpty()
   }

--- a/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/service/ProdJellyseerrService.kt
+++ b/core/network/src/main/kotlin/com/divinelink/core/network/jellyseerr/service/ProdJellyseerrService.kt
@@ -25,12 +25,12 @@ import kotlinx.coroutines.flow.flow
 class ProdJellyseerrService(private val restClient: JellyseerrRestClient) : JellyseerrService {
 
   override suspend fun signInWithJellyfin(jellyfinLogin: JellyseerrLoginData): Flow<Unit> = flow {
-    val url = "${jellyfinLogin.address}${AUTH_ENDPOINT}/jellyfin"
+    val url = "${jellyfinLogin.address.normalized}${AUTH_ENDPOINT}/jellyfin"
 
     val response = restClient.post<JellyseerrLoginRequestBodyApi, Unit>(
       url = url,
       body = JellyseerrLoginRequestBodyApi.Jellyfin(
-        username = jellyfinLogin.username.value,
+        username = jellyfinLogin.username.normalized,
         password = jellyfinLogin.password.value,
         serverType = jellyfinLogin.authMethod.serverType,
       ),
@@ -41,12 +41,12 @@ class ProdJellyseerrService(private val restClient: JellyseerrRestClient) : Jell
 
   override suspend fun signInWithJellyseerr(jellyseerrLogin: JellyseerrLoginData): Flow<Unit> =
     flow {
-      val url = "${jellyseerrLogin.address}${AUTH_ENDPOINT}/local"
+      val url = "${jellyseerrLogin.address.normalized}${AUTH_ENDPOINT}/local"
 
       val response = restClient.post<JellyseerrLoginRequestBodyApi, Unit>(
         url = url,
         body = JellyseerrLoginRequestBodyApi.Jellyseerr(
-          email = jellyseerrLogin.username.value,
+          email = jellyseerrLogin.username.normalized,
           password = jellyseerrLogin.password.value,
         ),
       )

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrLoginContent.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrLoginContent.kt
@@ -82,7 +82,7 @@ fun JellyseerrLoginContent(
         modifier = Modifier
           .testTag(TestTags.Settings.Jellyseerr.ADDRESS_TEXT_FIELD)
           .fillMaxWidth(),
-        value = state.loginData.address,
+        value = state.loginData.address.value,
         colors = OutlinedTextFieldDefaults.colors(
           focusedBorderColor = Color(0xFF6366F1),
           focusedLabelColor = Color(0xFF6366F1),

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModel.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModel.kt
@@ -7,6 +7,7 @@ import com.divinelink.core.commons.domain.onError
 import com.divinelink.core.domain.jellyseerr.GetJellyseerrProfileUseCase
 import com.divinelink.core.domain.jellyseerr.LoginJellyseerrUseCase
 import com.divinelink.core.domain.jellyseerr.LogoutJellyseerrUseCase
+import com.divinelink.core.model.Address
 import com.divinelink.core.model.Password
 import com.divinelink.core.model.UIText
 import com.divinelink.core.model.Username
@@ -127,7 +128,7 @@ class JellyseerrSettingsViewModel(
           jellyseerrState = when (val state = it.jellyseerrState) {
             is JellyseerrState.Login -> state.copy(
               loginData = uiState.value.jellyseerrState.loginData.copy(
-                address = interaction.address,
+                address = Address.from(interaction.address),
               ),
             )
             else -> state
@@ -171,7 +172,7 @@ class JellyseerrSettingsViewModel(
             is JellyseerrState.Login -> {
               state.copy(
                 loginData = state.loginData.copy(
-                  username = Username(interaction.username),
+                  username = Username.from(interaction.username),
                 ),
               )
             }

--- a/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/preview/JellyseerrLoginStatePreviewParameterProvider.kt
+++ b/feature/settings/src/main/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/preview/JellyseerrLoginStatePreviewParameterProvider.kt
@@ -2,6 +2,7 @@ package com.divinelink.feature.settings.app.account.jellyseerr.preview
 
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.divinelink.core.commons.ExcludeFromKoverReport
+import com.divinelink.core.model.Address
 import com.divinelink.core.model.Password
 import com.divinelink.core.model.Username
 import com.divinelink.core.model.jellyseerr.JellyseerrAuthMethod
@@ -19,8 +20,8 @@ class JellyseerrLoginStatePreviewParameterProvider :
     JellyseerrState.Login(
       isLoading = false,
       loginData = JellyseerrLoginData(
-        address = "https://jellyseerr.com",
-        username = Username("DavidLynch"),
+        address = Address.from("https://jellyseerr.com"),
+        username = Username.from("DavidLynch"),
         password = Password("password"),
         authMethod = JellyseerrAuthMethod.JELLYSEERR,
       ),
@@ -28,8 +29,8 @@ class JellyseerrLoginStatePreviewParameterProvider :
     JellyseerrState.Login(
       isLoading = false,
       loginData = JellyseerrLoginData(
-        address = "https://jellyseerr.com",
-        username = Username("DavidLynch"),
+        address = Address.from("https://jellyseerr.com"),
+        username = Username.from("DavidLynch"),
         password = Password("password"),
         authMethod = JellyseerrAuthMethod.JELLYFIN,
       ),
@@ -37,8 +38,8 @@ class JellyseerrLoginStatePreviewParameterProvider :
     JellyseerrState.Login(
       isLoading = false,
       loginData = JellyseerrLoginData(
-        address = "https://jellyseerr.com",
-        username = Username("DavidLynch"),
+        address = Address.from("https://jellyseerr.com"),
+        username = Username.from("DavidLynch"),
         password = Password("password"),
         authMethod = JellyseerrAuthMethod.EMBY,
       ),
@@ -46,8 +47,8 @@ class JellyseerrLoginStatePreviewParameterProvider :
     JellyseerrState.Login(
       isLoading = false,
       loginData = JellyseerrLoginData(
-        address = "https://jellyseerr.com",
-        username = Username("DavidLynch"),
+        address = Address.from("https://jellyseerr.com"),
+        username = Username.from("DavidLynch"),
         password = Password.empty(),
         authMethod = JellyseerrAuthMethod.EMBY,
       ),
@@ -55,8 +56,8 @@ class JellyseerrLoginStatePreviewParameterProvider :
     JellyseerrState.Login(
       isLoading = true,
       loginData = JellyseerrLoginData(
-        address = "https://jellyseerr.com",
-        username = Username("DavidLynch"),
+        address = Address.from("https://jellyseerr.com"),
+        username = Username.from("DavidLynch"),
         password = Password("password"),
         authMethod = JellyseerrAuthMethod.EMBY,
       ),

--- a/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModelTest.kt
+++ b/feature/settings/src/test/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModelTest.kt
@@ -5,6 +5,7 @@ import com.divinelink.core.commons.exception.InvalidStatusException
 import com.divinelink.core.domain.jellyseerr.JellyseerrProfileResult
 import com.divinelink.core.fixtures.model.jellyseerr.JellyseerrProfileFactory
 import com.divinelink.core.fixtures.model.jellyseerr.JellyseerrAccountDetailsResultFactory
+import com.divinelink.core.model.Address
 import com.divinelink.core.model.Password
 import com.divinelink.core.model.UIText
 import com.divinelink.core.model.Username
@@ -49,8 +50,8 @@ class JellyseerrSettingsViewModelTest {
           jellyseerrState = JellyseerrState.Login(
             isLoading = false,
             loginData = JellyseerrLoginData(
-              address = "http://localhost:8096",
-              username = Username("username"),
+              address = Address.from("http://localhost:8096"),
+              username = Username.from("username"),
               password = Password("password"),
               authMethod = JellyseerrAuthMethod.JELLYSEERR,
             ),
@@ -78,8 +79,8 @@ class JellyseerrSettingsViewModelTest {
           jellyseerrState = JellyseerrState.Login(
             isLoading = false,
             loginData = JellyseerrLoginData(
-              address = "http://localhost:8096",
-              username = Username("username"),
+              address = Address.from("http://localhost:8096"),
+              username = Username.from("username"),
               password = Password("password"),
               authMethod = JellyseerrAuthMethod.JELLYSEERR,
             ),
@@ -107,8 +108,8 @@ class JellyseerrSettingsViewModelTest {
           jellyseerrState = JellyseerrState.Login(
             isLoading = false,
             loginData = JellyseerrLoginData(
-              address = "http://localhost:8096",
-              username = Username("username"),
+              address = Address.from("http://localhost:8096"),
+              username = Username.from("username"),
               password = Password("password"),
               authMethod = JellyseerrAuthMethod.JELLYSEERR,
             ),
@@ -136,8 +137,8 @@ class JellyseerrSettingsViewModelTest {
           jellyseerrState = JellyseerrState.Login(
             isLoading = false,
             loginData = JellyseerrLoginData(
-              address = "http://localhost:8096",
-              username = Username("username"),
+              address = Address.from("http://localhost:8096"),
+              username = Username.from("username"),
               password = Password("password"),
               authMethod = JellyseerrAuthMethod.JELLYSEERR,
             ),
@@ -247,8 +248,8 @@ class JellyseerrSettingsViewModelTest {
           jellyseerrState = JellyseerrState.Login(
             isLoading = false,
             loginData = JellyseerrLoginData(
-              address = "http://localhost:8096",
-              username = Username("username"),
+              address = Address.from("http://localhost:8096"),
+              username = Username.from("username"),
               password = Password("password"),
               authMethod = JellyseerrAuthMethod.JELLYSEERR,
             ),
@@ -265,8 +266,8 @@ class JellyseerrSettingsViewModelTest {
           jellyseerrState = JellyseerrState.Login(
             isLoading = false,
             loginData = JellyseerrLoginData(
-              address = "http://localhost:8096",
-              username = Username("username"),
+              address = Address.from("http://localhost:8096"),
+              username = Username.from("username"),
               password = Password("password"),
               authMethod = JellyseerrAuthMethod.JELLYSEERR,
             ),
@@ -292,8 +293,8 @@ class JellyseerrSettingsViewModelTest {
           jellyseerrState = JellyseerrState.Login(
             isLoading = false,
             loginData = JellyseerrLoginData(
-              address = "http://localhost:8096",
-              username = Username("username"),
+              address = Address.from("http://localhost:8096"),
+              username = Username.from("username"),
               password = Password("password"),
               authMethod = JellyseerrAuthMethod.JELLYSEERR,
             ),
@@ -309,8 +310,8 @@ class JellyseerrSettingsViewModelTest {
           jellyseerrState = JellyseerrState.Login(
             isLoading = false,
             loginData = JellyseerrLoginData(
-              address = "http://localhost:8096",
-              username = Username("username"),
+              address = Address.from("http://localhost:8096"),
+              username = Username.from("username"),
               password = Password("password"),
               authMethod = JellyseerrAuthMethod.JELLYSEERR,
             ),


### PR DESCRIPTION
### Summary

Trims trailing characters on jellyseerr auth fields to reduce authentication errors if the users has typed any trailing characters by mistake. 

Closes #197 