### PR TITLE
Fix nullable field on person details response

### DIFF
--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/details/person/model/PersonDetailsApi.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/details/person/model/PersonDetailsApi.kt
@@ -12,7 +12,7 @@ data class PersonDetailsApi(
   val homepage: String?,
   val id: Long,
   @SerialName("imdb_id") val imdbId: String?,
-  @SerialName("known_for_department") val knownForDepartment: String,
+  @SerialName("known_for_department") val knownForDepartment: String?,
   val name: String,
   @SerialName("place_of_birth") val placeOfBirth: String?,
   val popularity: Double,


### PR DESCRIPTION
### Summary

Although rare, it may happen that `knownForDepartment` field on person details response can be null. Fixing it by making the field nullable. 