### PR TITLE
[Jellyseerr] Add detailed error dialog for CSRF protection

### DIFF
--- a/core/model/src/commonMain/kotlin/com/divinelink/core/model/exception/ExceptionConstants.kt
+++ b/core/model/src/commonMain/kotlin/com/divinelink/core/model/exception/ExceptionConstants.kt
@@ -1,0 +1,5 @@
+package com.divinelink.core.model.exception
+
+object ExceptionConstants {
+  const val INVALID_CSRF_TOKEN = "invalid csrf token"
+}

--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/KtorClient.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/KtorClient.kt
@@ -5,6 +5,8 @@ package com.divinelink.core.network.client
 import com.divinelink.core.commons.Constants
 import com.divinelink.core.commons.provider.BuildConfigProvider
 import com.divinelink.core.model.exception.AppException
+import com.divinelink.core.network.client.error.ClientErrorResponse
+import com.divinelink.core.network.client.error.extractErrorMessage
 import io.github.aakira.napier.Napier
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
@@ -73,15 +75,17 @@ fun ktorClient(
       if (!response.status.isSuccess()) {
         val statusCode = response.status.value
         val status = response.status.toString()
+        val errorMessage = response.extractErrorMessage<ClientErrorResponse>() ?: status
+
         val error = when (statusCode) {
-          HttpStatusCode.Unauthorized.value -> AppException.Unauthorized(status)
-          HttpStatusCode.Forbidden.value -> AppException.Forbidden(status)
-          HttpStatusCode.NotFound.value -> AppException.NotFound(status)
-          HttpStatusCode.Conflict.value -> AppException.Conflict(status)
-          HttpStatusCode.TooManyRequests.value -> AppException.TooManyRequests(status)
-          HttpStatusCode.PayloadTooLarge.value -> AppException.PayloadTooLarge(status)
-          in 500..599 -> AppException.ServerError(status)
-          else -> AppException.BadRequest(status)
+          HttpStatusCode.Unauthorized.value -> AppException.Unauthorized(errorMessage)
+          HttpStatusCode.Forbidden.value -> AppException.Forbidden(errorMessage)
+          HttpStatusCode.NotFound.value -> AppException.NotFound(errorMessage)
+          HttpStatusCode.Conflict.value -> AppException.Conflict(errorMessage)
+          HttpStatusCode.TooManyRequests.value -> AppException.TooManyRequests(errorMessage)
+          HttpStatusCode.PayloadTooLarge.value -> AppException.PayloadTooLarge(errorMessage)
+          in 500..599 -> AppException.ServerError(errorMessage)
+          else -> AppException.BadRequest(errorMessage)
         }
         throw error
       }

--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/error/ClientErrorResponse.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/error/ClientErrorResponse.kt
@@ -1,0 +1,23 @@
+package com.divinelink.core.network.client.error
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable(with = ClientErrorResponseSerializer::class)
+sealed interface ClientErrorResponse {
+
+  @Serializable
+  data class Jellyseerr(
+    val message: String,
+  ) : ClientErrorResponse
+
+  @Serializable
+  data class TMDB(
+    @SerialName("status_code") val statusCode: Int,
+    @SerialName("status_message") val statusMessage: String,
+    @SerialName("success") val success: Boolean,
+  ) : ClientErrorResponse
+
+  @Serializable
+  data object Unknown : ClientErrorResponse
+}

--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/error/ClientErrorResponseSerializer.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/error/ClientErrorResponseSerializer.kt
@@ -1,0 +1,38 @@
+package com.divinelink.core.network.client.error
+
+import com.divinelink.core.network.client.decode
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.jsonObject
+
+object ClientErrorResponseSerializer : KSerializer<ClientErrorResponse> {
+  override val descriptor: SerialDescriptor = buildClassSerialDescriptor(
+    serialName = ClientErrorResponse::class.simpleName.toString(),
+  )
+
+  override fun deserialize(decoder: Decoder): ClientErrorResponse {
+    val jsonInput = decoder as? JsonDecoder ?: error("Can be deserialized only by JSON")
+
+    val json = jsonInput.decodeJsonElement().jsonObject
+
+    return when {
+      json.containsKey("status_message") &&
+        json.containsKey("status_code") &&
+        json.containsKey("success") -> json.decode<ClientErrorResponse.TMDB>()
+      json.containsKey("message") -> json.decode<ClientErrorResponse.Jellyseerr>()
+      else -> throw SerializationException("Unknown type: $json")
+    }
+  }
+
+  override fun serialize(
+    encoder: Encoder,
+    value: ClientErrorResponse,
+  ) {
+    error("Serialization is not supported")
+  }
+}

--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/error/ErrorMessageExtractor.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/error/ErrorMessageExtractor.kt
@@ -1,0 +1,21 @@
+package com.divinelink.core.network.client.error
+
+import io.ktor.client.call.body
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+
+suspend inline fun <reified T : ClientErrorResponse> HttpResponse.extractErrorMessage(): String? {
+  return try {
+    when (val error = body<T>()) {
+      is ClientErrorResponse.Jellyseerr -> error.message
+      is ClientErrorResponse.TMDB -> error.statusMessage
+      ClientErrorResponse.Unknown -> null
+    }
+  } catch (_: Exception) {
+    try {
+      bodyAsText().takeIf { it.isNotBlank() }
+    } catch (_: Exception) {
+      null
+    }
+  }
+}

--- a/core/network/src/commonTest/kotlin/com/divinelink/core/network/client/error/ClientErrorResponseSerializerTest.kt
+++ b/core/network/src/commonTest/kotlin/com/divinelink/core/network/client/error/ClientErrorResponseSerializerTest.kt
@@ -1,0 +1,57 @@
+package com.divinelink.core.network.client.error
+
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class ClientErrorResponseSerializerTest {
+
+  private val serializer = ClientErrorResponseSerializer
+
+  @Test
+  fun `test serialize client error with message`() {
+    val response = """
+      {"message": "invalid csrf token"}
+    """.trimIndent()
+
+    val json = Json.decodeFromString(serializer, response)
+
+    json shouldBe ClientErrorResponse.Jellyseerr("invalid csrf token")
+  }
+
+  @Test
+  fun `test serialize client error with status_message`() {
+    val response = """
+      {
+        "status_code": 7,
+        "status_message": "Invalid API key: You must be granted a valid key.",
+        "success": false
+      }
+    """.trimIndent()
+
+    val json = Json.decodeFromString(serializer, response)
+
+    json shouldBe ClientErrorResponse.TMDB(
+      statusCode = 7,
+      statusMessage = "Invalid API key: You must be granted a valid key.",
+      success = false,
+    )
+  }
+
+  @Test
+  fun `test serialize client error with unknown properties`() {
+    val response = """
+      {
+        "status_code": 7
+      }
+    """.trimIndent()
+
+    assertFailsWith<SerializationException> {
+      Json.decodeFromString(serializer, response)
+    }.apply {
+      message shouldBe "Unknown type: {\"status_code\":7}"
+    }
+  }
+}

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -22,6 +22,7 @@
   <string name="feature_settings_currently_login_dialog_summary">You are currently logged in as %1$s. Do you want to logout?</string>
 
   <string name="feature_settings_invalid_credentials">The credentials you entered are invalid.</string>
+  <string name="feature_settings_csrf_enabled">Your server currently has CSRF protection enabled.\n\nTo allow third-party applications like ScenePeek to make external API calls to your server, you'll need to disable CSRF.\n\nIf you're not the server administrator, please contact your admin for assistance.</string>
   <string name="feature_settings_could_not_connect">Could not connect to server. Make sure the IP address is correct and the server is running.</string>
 
   <string name="feature_settings_jellyseerr_description">Add your Jellyseerr IP Address and select a sign-in method to enable Jellyseerr.\nMake sure to include the full URL with https:// or http:// and port number if needed.</string>

--- a/feature/settings/src/commonMain/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModel.kt
+++ b/feature/settings/src/commonMain/kotlin/com/divinelink/feature/settings/app/account/jellyseerr/JellyseerrSettingsViewModel.kt
@@ -14,6 +14,7 @@ import com.divinelink.core.model.Password
 import com.divinelink.core.model.UIText
 import com.divinelink.core.model.Username
 import com.divinelink.core.model.exception.AppException
+import com.divinelink.core.model.exception.ExceptionConstants
 import com.divinelink.core.model.jellyseerr.JellyseerrLoginData
 import com.divinelink.core.model.jellyseerr.JellyseerrState
 import com.divinelink.core.ui.UiString
@@ -22,6 +23,7 @@ import com.divinelink.core.ui.resources.core_ui_error_retry
 import com.divinelink.core.ui.snackbar.SnackbarMessage
 import com.divinelink.feature.settings.resources.Res
 import com.divinelink.feature.settings.resources.feature_settings_could_not_connect
+import com.divinelink.feature.settings.resources.feature_settings_csrf_enabled
 import com.divinelink.feature.settings.resources.feature_settings_invalid_credentials
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -107,9 +109,13 @@ class JellyseerrSettingsViewModel(
                 is AppException.Unauthorized -> UIText.ResourceText(
                   Res.string.feature_settings_invalid_credentials,
                 )
-                is AppException.Forbidden -> UIText.ResourceText(
-                  Res.string.feature_settings_invalid_credentials,
-                )
+                is AppException.Forbidden -> if (
+                  error.message == ExceptionConstants.INVALID_CSRF_TOKEN
+                ) {
+                  UIText.ResourceText(Res.string.feature_settings_csrf_enabled)
+                } else {
+                  UIText.ResourceText(Res.string.feature_settings_invalid_credentials)
+                }
                 is AppException.Offline -> UIText.ResourceText(
                   Res.string.feature_settings_could_not_connect,
                 )


### PR DESCRIPTION
### Summary 

Adds detailed error dialog when CSRF protection is enabled on seerr instance which informs the user about CSRF and that it should be disabled for authentication to work.

Additionally, updated KtorClient to correctly serialize error response for TMDB and Seerr apis.

Fixes #209