### PR TITLE
Fix crash for duplicate ids on movie cast due to invalid data from API

### DIFF
--- a/feature/details/src/commonMain/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/commonMain/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -184,7 +184,7 @@ class DetailsViewModel(
                     this[castOrder] = DetailsForm.Content(
                       DetailsData.Cast(
                         isTv = false,
-                        items = (data.mediaDetails as Movie).cast,
+                        items = (data.mediaDetails as Movie).cast.distinctBy { it.id },
                       ),
                     )
                   }
@@ -254,7 +254,7 @@ class DetailsViewModel(
                   this[castOrder] = DetailsForm.Content(
                     DetailsData.Cast(
                       isTv = true,
-                      items = credits.cast,
+                      items = credits.cast.distinctBy { it.id },
                     ),
                   )
                 }

--- a/feature/home/src/androidHostTest/kotlin/com/divinelink/feature/home/HomeScreenTest.kt
+++ b/feature/home/src/androidHostTest/kotlin/com/divinelink/feature/home/HomeScreenTest.kt
@@ -1,3 +1,0 @@
-package com.divinelink.feature.home
-
-// class HomeScreenTest : ComposeTest()

--- a/feature/home/src/commonTest/kotlin/com/divinelink/feature/home/HomeContentTest.kt
+++ b/feature/home/src/commonTest/kotlin/com/divinelink/feature/home/HomeContentTest.kt
@@ -1,3 +1,0 @@
-package com.divinelink.feature.home
-
-// class HomeContentTest : ComposeTest()


### PR DESCRIPTION
### Summary

Fixes an edge case crash where API response for movie cast would return duplicate entries for the same person.