### PR TITLE
[Bug] Make popularity nullable in case of invalid api data

### DIFF
--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/media/model/search/multi/MultiSearchResultApi.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/media/model/search/multi/MultiSearchResultApi.kt
@@ -18,7 +18,7 @@ data class MultiSearchResultApi(
   @SerialName("media_type") val mediaType: String?,
   @SerialName("genre_ids") val genreIds: List<Int>? = null,
   val gender: Int? = null,
-  @SerialName("popularity") val popularity: Double,
+  @SerialName("popularity") val popularity: Double?,
   @SerialName("first_air_date") val firstAirDate: String? = null,
   @SerialName("release_date") val releaseDate: String? = null,
   @SerialName("vote_average") val voteAverage: Double? = null,

--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/media/model/search/multi/mapper/MultiSearchResponseApiMapper.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/media/model/search/multi/mapper/MultiSearchResponseApiMapper.kt
@@ -29,7 +29,7 @@ fun List<MultiSearchResultApi>.map(mediaType: String?): List<MediaItem> = this.m
       voteAverage = it.voteAverage?.round(1) ?: 0.0,
       voteCount = it.voteCount ?: 0,
       overview = it.overview ?: "",
-      popularity = it.popularity,
+      popularity = it.popularity ?: 0.0,
       isFavorite = false,
     )
     MediaType.MOVIE -> MediaItem.Media.Movie(
@@ -41,7 +41,7 @@ fun List<MultiSearchResultApi>.map(mediaType: String?): List<MediaItem> = this.m
       voteAverage = it.voteAverage?.round(1) ?: 0.0,
       voteCount = it.voteCount ?: 0,
       overview = it.overview!!,
-      popularity = it.popularity,
+      popularity = it.popularity ?: 0.0,
       isFavorite = false,
     )
     MediaType.PERSON -> MediaItem.Person(

--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/media/model/search/multi/mapper/MultiSearchResultApiMapperToMedia.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/media/model/search/multi/mapper/MultiSearchResultApiMapperToMedia.kt
@@ -16,7 +16,7 @@ fun List<MultiSearchResultApi>.mapToMedia(): List<MediaItem.Media> = this.mapNot
       voteAverage = it.voteAverage?.round(1) ?: 0.0,
       voteCount = it.voteCount ?: 0,
       overview = it.overview ?: "",
-      popularity = it.popularity,
+      popularity = it.popularity ?: 0.0,
       isFavorite = false,
     )
     MediaType.MOVIE -> MediaItem.Media.Movie(
@@ -28,7 +28,7 @@ fun List<MultiSearchResultApi>.mapToMedia(): List<MediaItem.Media> = this.mapNot
       voteAverage = it.voteAverage?.round(1) ?: 0.0,
       voteCount = it.voteCount ?: 0,
       overview = it.overview ?: "",
-      popularity = it.popularity,
+      popularity = it.popularity ?: 0.0,
       isFavorite = false,
     )
     MediaType.PERSON -> null


### PR DESCRIPTION
### Summary

Make `popularity` field nullable in search response since some responses may wrongly return popularity as null which results in error state. 