### PR TITLE
Fix list details error on unauthenticated users

### DIFF
--- a/app/src/androidHostTest/kotlin/com/divinelink/scenepeek/ui/ScenePeekAppTest.kt
+++ b/app/src/androidHostTest/kotlin/com/divinelink/scenepeek/ui/ScenePeekAppTest.kt
@@ -39,6 +39,8 @@ import com.divinelink.core.scaffold.ScenePeekApp
 import com.divinelink.core.scaffold.ScenePeekAppState
 import com.divinelink.core.scaffold.TopLevelDestination
 import com.divinelink.core.scaffold.rememberScenePeekAppState
+import com.divinelink.core.scaffold.resources.top_level_navigation_content_description_selected
+import com.divinelink.core.scaffold.resources.top_level_navigation_content_description_unselected
 import com.divinelink.core.testing.ComposeTest
 import com.divinelink.core.testing.MainDispatcherRule
 import com.divinelink.core.testing.repository.TestAuthRepository
@@ -76,8 +78,6 @@ import com.divinelink.feature.onboarding.ui.IntroViewModel
 import com.divinelink.feature.profile.ProfileViewModel
 import com.divinelink.feature.search.ui.SearchViewModel
 import com.divinelink.scenepeek.di.navigationModule
-import com.divinelink.scenepeek.resources.top_level_navigation_content_description_selected
-import com.divinelink.scenepeek.resources.top_level_navigation_content_description_unselected
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceTimeBy
@@ -91,7 +91,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.time.Clock
-import com.divinelink.scenepeek.resources.Res as R
+import com.divinelink.core.scaffold.resources.Res as scaffoldR
 
 class ScenePeekAppTest : ComposeTest() {
 
@@ -213,17 +213,17 @@ class ScenePeekAppTest : ComposeTest() {
     onNodeWithText(profileTab).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, homeTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, profileTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, profileTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, searchTab),
       useUnmergedTree = true,
     ).assertExists()
   }
@@ -271,24 +271,24 @@ class ScenePeekAppTest : ComposeTest() {
     onNodeWithText(profileTab).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, homeTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, profileTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, profileTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithText(profileTab).performClick()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, profileTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, profileTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, homeTab),
       useUnmergedTree = true,
     ).assertExists()
   }
@@ -342,24 +342,24 @@ class ScenePeekAppTest : ComposeTest() {
     onNodeWithText(homeTab).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, homeTab),
       useUnmergedTree = true,
     ).assertIsDisplayed()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, searchTab),
       useUnmergedTree = true,
     ).assertIsDisplayed()
 
     onNodeWithTag(TestTags.Components.SearchBar.CLICKABLE_SEARCH_BAR).performClick()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, searchTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, homeTab),
       useUnmergedTree = true,
     ).assertExists()
 
@@ -421,24 +421,24 @@ class ScenePeekAppTest : ComposeTest() {
     onNodeWithText(homeTab).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, homeTab),
       useUnmergedTree = true,
     ).assertIsDisplayed()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, searchTab),
       useUnmergedTree = true,
     ).assertIsDisplayed()
 
     onNodeWithTag(TestTags.Components.SearchBar.CLICKABLE_SEARCH_BAR).performClick()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, searchTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, homeTab),
       useUnmergedTree = true,
     ).assertExists()
 
@@ -453,12 +453,12 @@ class ScenePeekAppTest : ComposeTest() {
     ).assertIsDisplayed()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, homeTab),
       useUnmergedTree = true,
     ).performClick()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, searchTab),
       useUnmergedTree = true,
     ).performClick()
 
@@ -513,24 +513,24 @@ class ScenePeekAppTest : ComposeTest() {
     onNodeWithText(homeTab).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, homeTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, searchTab),
       useUnmergedTree = true,
     )
       .assertExists()
       .performClick()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, searchTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, homeTab),
       useUnmergedTree = true,
     ).assertExists()
   }
@@ -581,24 +581,24 @@ class ScenePeekAppTest : ComposeTest() {
     onNodeWithText(homeTab).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, homeTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, searchTab),
       useUnmergedTree = true,
     )
       .assertExists()
       .performClick()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, searchTab),
       useUnmergedTree = true,
     ).assertExists()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_unselected, homeTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_unselected, homeTab),
       useUnmergedTree = true,
     ).assertExists()
 
@@ -611,7 +611,7 @@ class ScenePeekAppTest : ComposeTest() {
     ).assertIsNotDisplayed()
 
     onNodeWithContentDescription(
-      getString(R.string.top_level_navigation_content_description_selected, searchTab),
+      getString(scaffoldR.string.top_level_navigation_content_description_selected, searchTab),
       useUnmergedTree = true,
     ).performClick()
 

--- a/app/src/commonMain/composeResources/values/strings.xml
+++ b/app/src/commonMain/composeResources/values/strings.xml
@@ -1,17 +1,2 @@
 <resources>
-  <string name="close">Close</string>
-  <string name="save">Save</string>
-  <string name="update">Update</string>
-
-  <!-- Error -->
-  <string name="empty_field_error_message">%1$s is required.</string>
-  <string name="general_error_message">Something when wrong.</string>
-
-  <string name="delete">Delete</string>
-  <string name="cancel">Cancel</string>
-
-  <!-- Accessibility -->
-  <string name="movie_image_placeholder">Movie image</string>
-  <string name="top_level_navigation_content_description_selected">Selected bottom navigation item %1$s</string>
-  <string name="top_level_navigation_content_description_unselected">Unselected bottom navigation item %1$s</string>
 </resources>

--- a/core/fixtures/src/commonMain/kotlin/com/divinelink/core/fixtures/model/account/AccountDetailsFactory.kt
+++ b/core/fixtures/src/commonMain/kotlin/com/divinelink/core/fixtures/model/account/AccountDetailsFactory.kt
@@ -10,4 +10,11 @@ object AccountDetailsFactory {
     name = "Jessee Pinkman",
     tmdbAvatarPath = "/avatar/pinkman.jpg",
   )
+
+  val elsa = AccountDetails(
+    id = 2,
+    username = "Elsa",
+    name = "Elsa Skilouri",
+    tmdbAvatarPath = "/avatar/elsa.jpg",
+  )
 }

--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/AuthTMDbClient.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/AuthTMDbClient.kt
@@ -24,7 +24,7 @@ class AuthTMDbClient(
       contentType(ContentType.Application.Json)
       encryptedStorage.accessToken?.let { accessToken ->
         bearerAuth(accessToken)
-      }
+      } ?: bearerAuth(secret.tmdbAuth)
     }
   }
 

--- a/core/scaffold/build.gradle.kts
+++ b/core/scaffold/build.gradle.kts
@@ -15,7 +15,7 @@ kotlin {
 }
 
 compose.resources {
-  publicResClass = false
+  publicResClass = true
   packageOfResClass = "com.divinelink.core.scaffold.resources"
   generateResClass = auto
 }

--- a/feature/lists/src/androidHostTest/kotlin/com/divinelink/feature/lists/details/ListDetailsScreenTest.kt
+++ b/feature/lists/src/androidHostTest/kotlin/com/divinelink/feature/lists/details/ListDetailsScreenTest.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.test.performTouchInput
 import androidx.compose.ui.test.swipeDown
 import com.divinelink.core.domain.components.SwitchViewButtonViewModel
 import com.divinelink.core.fixtures.data.preferences.TestPreferencesRepository
+import com.divinelink.core.fixtures.model.account.AccountDetailsFactory
 import com.divinelink.core.fixtures.model.list.ListDetailsFactory
 import com.divinelink.core.model.ScreenType
 import com.divinelink.core.model.exception.AppException
@@ -27,6 +28,7 @@ import com.divinelink.core.navigation.route.Navigation.DetailsRoute
 import com.divinelink.core.navigation.route.Navigation.EditListRoute
 import com.divinelink.core.navigation.route.Navigation.ListDetailsRoute
 import com.divinelink.core.testing.ComposeTest
+import com.divinelink.core.testing.repository.TestAuthRepository
 import com.divinelink.core.testing.repository.TestListRepository
 import com.divinelink.core.testing.setVisibilityScopeContent
 import com.divinelink.core.testing.uiTest
@@ -57,6 +59,7 @@ import com.divinelink.feature.add.to.account.resources.Res as R
 class ListDetailsScreenTest : ComposeTest() {
 
   private val repository = TestListRepository()
+  private val authRepository = TestAuthRepository()
   private val markAsFavoriteUseCase = TestMarkAsFavoriteUseCase()
 
   private lateinit var preferencesRepository: TestPreferencesRepository
@@ -102,10 +105,13 @@ class ListDetailsScreenTest : ComposeTest() {
     var navigatedUp = false
     val fetchListDetailsUseCase = TestFetchListDetailsUseCase()
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent {
@@ -127,6 +133,35 @@ class ListDetailsScreenTest : ComposeTest() {
   }
 
   @Test
+  fun `test on edit fab is not visible on other users list`() = uiTest {
+    val fetchListDetailsUseCase = TestFetchListDetailsUseCase()
+
+    fetchListDetailsUseCase.mockResponse(
+      Result.success(ListDetailsFactory.mustWatch()),
+    )
+
+    authRepository.mockTMDBAccount(AccountDetailsFactory.Pinkman())
+
+    val viewModel = ListDetailsViewModel(
+      fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
+      route = route,
+      repository = repository.mock,
+      authRepository = authRepository.mock,
+    )
+
+    setVisibilityScopeContent {
+      ListDetailsScreen(
+        route = route,
+        onNavigate = {},
+        viewModel = viewModel,
+        switchViewButtonViewModel = switchViewButtonViewModel,
+      )
+    }
+
+    onNodeWithTag(TestTags.Lists.Details.EDIT_LIST_FAB).assertIsNotDisplayed()
+  }
+
+  @Test
   fun `test refresh action`() = uiTest {
     val fetchListDetailsUseCase = TestFetchListDetailsUseCase()
 
@@ -134,10 +169,13 @@ class ListDetailsScreenTest : ComposeTest() {
       Result.success(ListDetailsFactory.empty()),
     )
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent {
@@ -176,10 +214,13 @@ class ListDetailsScreenTest : ComposeTest() {
       Result.success(ListDetailsFactory.mustWatch()),
     )
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent {
@@ -219,10 +260,13 @@ class ListDetailsScreenTest : ComposeTest() {
       Result.success(ListDetailsFactory.page1()),
     )
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent {
@@ -273,10 +317,13 @@ class ListDetailsScreenTest : ComposeTest() {
       Result.failure(AppException.Offline()),
     )
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent {
@@ -310,10 +357,13 @@ class ListDetailsScreenTest : ComposeTest() {
       Result.failure(Exception("Foo")),
     )
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent {
@@ -359,10 +409,13 @@ class ListDetailsScreenTest : ComposeTest() {
       )
     }
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent {
@@ -395,10 +448,13 @@ class ListDetailsScreenTest : ComposeTest() {
       Result.success(ListDetailsFactory.page1()),
     )
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent {
@@ -447,10 +503,13 @@ class ListDetailsScreenTest : ComposeTest() {
       )
     }
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent {
@@ -559,10 +618,13 @@ class ListDetailsScreenTest : ComposeTest() {
       )
     }
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent {
@@ -619,10 +681,13 @@ class ListDetailsScreenTest : ComposeTest() {
       )
     }
 
+    authRepository.mockTMDBAccount(AccountDetailsFactory.elsa)
+
     val viewModel = ListDetailsViewModel(
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       route = route,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
 
     setVisibilityScopeContent(

--- a/feature/lists/src/androidHostTest/kotlin/com/divinelink/feature/lists/details/ListDetailsViewModelTest.kt
+++ b/feature/lists/src/androidHostTest/kotlin/com/divinelink/feature/lists/details/ListDetailsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.divinelink.feature.lists.details
 
+import com.divinelink.core.fixtures.model.account.AccountDetailsFactory
 import com.divinelink.core.fixtures.model.list.ListDetailsFactory
 import com.divinelink.core.model.UIText
 import com.divinelink.core.model.exception.AppException
@@ -36,6 +37,7 @@ class ListDetailsViewModelTest {
   fun `test fetch data`() {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -54,6 +56,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
   }
@@ -62,6 +65,7 @@ class ListDetailsViewModelTest {
   fun `test refresh correctly clears pages`() = runTest {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.page1()),
       )
@@ -80,8 +84,10 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.page2()),
       )
@@ -103,8 +109,10 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -129,6 +137,7 @@ class ListDetailsViewModelTest {
             snackbarMessage = null,
             selectedMedia = emptyList(),
             multipleSelectMode = false,
+            canEdit = true,
           ),
           ListDetailsUiState(
             id = 1,
@@ -146,6 +155,7 @@ class ListDetailsViewModelTest {
             snackbarMessage = null,
             selectedMedia = emptyList(),
             multipleSelectMode = false,
+            canEdit = true,
           ),
           ListDetailsUiState(
             id = 1,
@@ -162,6 +172,7 @@ class ListDetailsViewModelTest {
             snackbarMessage = null,
             selectedMedia = emptyList(),
             multipleSelectMode = false,
+            canEdit = true,
           ),
         ),
       )
@@ -171,6 +182,7 @@ class ListDetailsViewModelTest {
   fun `test load more when cannot load more`() = runTest {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -189,6 +201,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
       .onLoadMore()
@@ -206,6 +219,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
   }
@@ -214,6 +228,7 @@ class ListDetailsViewModelTest {
   fun `test load more correctly sets loading more`() = runTest {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.page1()),
       )
@@ -232,8 +247,10 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.page2()),
       )
@@ -255,6 +272,7 @@ class ListDetailsViewModelTest {
             snackbarMessage = null,
             selectedMedia = emptyList(),
             multipleSelectMode = false,
+            canEdit = true,
           ),
           ListDetailsUiState(
             id = 1,
@@ -269,6 +287,7 @@ class ListDetailsViewModelTest {
             snackbarMessage = null,
             selectedMedia = emptyList(),
             multipleSelectMode = false,
+            canEdit = true,
           ),
           ListDetailsUiState(
             id = 1,
@@ -286,6 +305,7 @@ class ListDetailsViewModelTest {
             snackbarMessage = null,
             selectedMedia = emptyList(),
             multipleSelectMode = false,
+            canEdit = true,
           ),
         ),
       )
@@ -295,6 +315,7 @@ class ListDetailsViewModelTest {
   fun `test load more with error when data not initial does not set error`() {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -313,8 +334,10 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.failure(Exception("Foo")),
       )
@@ -333,6 +356,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
   }
@@ -341,6 +365,7 @@ class ListDetailsViewModelTest {
   fun `test initial with error`() {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.failure(Exception("Foo")),
       )
@@ -361,6 +386,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = false,
         ),
       )
   }
@@ -369,6 +395,7 @@ class ListDetailsViewModelTest {
   fun `test initial with connection error sets offline blank slate`() {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.failure(AppException.Offline()),
       )
@@ -389,6 +416,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = false,
         ),
       )
   }
@@ -397,6 +425,7 @@ class ListDetailsViewModelTest {
   fun `test on select all items`() {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -415,6 +444,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
       .onSelectMedia(
@@ -434,6 +464,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = listOf(ListDetailsFactory.mustWatch().media.first()),
           multipleSelectMode = true,
+          canEdit = true,
         ),
       )
       .onSelectAll()
@@ -451,6 +482,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = ListDetailsFactory.mustWatch().media,
           multipleSelectMode = true,
+          canEdit = true,
         ),
       )
   }
@@ -459,6 +491,7 @@ class ListDetailsViewModelTest {
   fun `test on deselect all items`() {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -477,6 +510,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
       .onSelectAll()
@@ -494,6 +528,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = ListDetailsFactory.mustWatch().media,
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
       .onDeselectAll()
@@ -511,6 +546,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
   }
@@ -521,6 +557,7 @@ class ListDetailsViewModelTest {
   fun `test on remove single selected item`() = runTest {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -539,6 +576,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
       .onSelectMedia(
@@ -558,6 +596,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = listOf(ListDetailsFactory.mustWatch().media.first()),
           multipleSelectMode = true,
+          canEdit = true,
         ),
       )
       .mockRemoveItems(Result.success(1))
@@ -582,6 +621,7 @@ class ListDetailsViewModelTest {
           ),
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
   }
@@ -590,6 +630,7 @@ class ListDetailsViewModelTest {
   fun `test on batch remove items`() = runTest {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -608,6 +649,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
       .onSelectMedia(ListDetailsFactory.mustWatch().media[0])
@@ -627,6 +669,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = ListDetailsFactory.mustWatch().media,
           multipleSelectMode = true,
+          canEdit = true,
         ),
       )
       .mockRemoveItems(Result.success(3))
@@ -651,6 +694,7 @@ class ListDetailsViewModelTest {
           ),
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
   }
@@ -659,6 +703,7 @@ class ListDetailsViewModelTest {
   fun `test on remove selected items with 0 result`() = runTest {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -677,6 +722,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
       .onSelectMedia(
@@ -696,6 +742,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = listOf(ListDetailsFactory.mustWatch().media.first()),
           multipleSelectMode = true,
+          canEdit = true,
         ),
       )
       .mockRemoveItems(Result.success(0))
@@ -714,6 +761,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
   }
@@ -722,6 +770,7 @@ class ListDetailsViewModelTest {
   fun `test on remove selected items with error`() = runTest {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -740,6 +789,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
       .onSelectMedia(
@@ -759,6 +809,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = listOf(ListDetailsFactory.mustWatch().media.first()),
           multipleSelectMode = true,
+          canEdit = true,
         ),
       )
       .mockRemoveItems(Result.failure(Exception("Failed to remove items")))
@@ -777,6 +828,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = SnackbarMessage.from(UIText.StringText("Failed to remove items")),
           selectedMedia = listOf(ListDetailsFactory.mustWatch().media.first()),
           multipleSelectMode = true,
+          canEdit = true,
         ),
       )
       .onConsumeSnackbarMessage()
@@ -794,6 +846,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = listOf(ListDetailsFactory.mustWatch().media.first()),
           multipleSelectMode = true,
+          canEdit = true,
         ),
       )
   }
@@ -802,6 +855,7 @@ class ListDetailsViewModelTest {
   fun `test on remove selected items when offline`() = runTest {
     robot
       .withArgs(listDetailsRoute)
+      .mockTMDBAccount(AccountDetailsFactory.elsa)
       .mockListDetails(
         Result.success(ListDetailsFactory.mustWatch()),
       )
@@ -820,6 +874,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = emptyList(),
           multipleSelectMode = false,
+          canEdit = true,
         ),
       )
       .onSelectMedia(
@@ -839,6 +894,7 @@ class ListDetailsViewModelTest {
           snackbarMessage = null,
           selectedMedia = listOf(ListDetailsFactory.mustWatch().media.first()),
           multipleSelectMode = true,
+          canEdit = true,
         ),
       )
       .mockRemoveItems(Result.failure(AppException.Offline()))
@@ -861,6 +917,7 @@ class ListDetailsViewModelTest {
           ),
           selectedMedia = listOf(ListDetailsFactory.mustWatch().media.first()),
           multipleSelectMode = true,
+          canEdit = true,
         ),
       )
   }

--- a/feature/lists/src/androidHostTest/kotlin/com/divinelink/feature/lists/details/ListDetailsViewModelTestRobot.kt
+++ b/feature/lists/src/androidHostTest/kotlin/com/divinelink/feature/lists/details/ListDetailsViewModelTestRobot.kt
@@ -1,10 +1,12 @@
 package com.divinelink.feature.lists.details
 
+import com.divinelink.core.model.account.AccountDetails
 import com.divinelink.core.model.list.ListDetails
 import com.divinelink.core.model.media.MediaItem
 import com.divinelink.core.navigation.route.Navigation
 import com.divinelink.core.testing.MainDispatcherRule
 import com.divinelink.core.testing.ViewModelTestRobot
+import com.divinelink.core.testing.repository.TestAuthRepository
 import com.divinelink.core.testing.repository.TestListRepository
 import com.divinelink.core.testing.usecase.TestFetchListDetailsUseCase
 import com.google.common.truth.Truth.assertThat
@@ -19,6 +21,7 @@ class ListDetailsViewModelTestRobot : ViewModelTestRobot<ListDetailsUiState>() {
 
   private val fetchListDetailsUseCase = TestFetchListDetailsUseCase()
   private val repository = TestListRepository()
+  private val authRepository = TestAuthRepository()
 
   @get:Rule
   val mainDispatcherRule = MainDispatcherRule()
@@ -28,6 +31,7 @@ class ListDetailsViewModelTestRobot : ViewModelTestRobot<ListDetailsUiState>() {
       route = navArgs,
       fetchListDetailsUseCase = fetchListDetailsUseCase.mock,
       repository = repository.mock,
+      authRepository = authRepository.mock,
     )
   }
 
@@ -68,6 +72,10 @@ class ListDetailsViewModelTestRobot : ViewModelTestRobot<ListDetailsUiState>() {
 
   fun assertUiState(expectedUiState: ListDetailsUiState) = apply {
     assertThat(viewModel.uiState.value).isEqualTo(expectedUiState)
+  }
+
+  fun mockTMDBAccount(accountDetails: AccountDetails?) = apply {
+    authRepository.mockTMDBAccount(accountDetails)
   }
 
   fun mockListDetails(response: Result<ListDetails>) = apply {

--- a/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ListDetailsUiState.kt
+++ b/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ListDetailsUiState.kt
@@ -16,6 +16,7 @@ data class ListDetailsUiState(
   val selectedMedia: List<MediaItem.Media>,
   val multipleSelectMode: Boolean,
   val snackbarMessage: SnackbarMessage?,
+  val canEdit: Boolean,
 ) {
   companion object {
     fun initial(
@@ -39,6 +40,7 @@ data class ListDetailsUiState(
       selectedMedia = emptyList(),
       multipleSelectMode = false,
       snackbarMessage = null,
+      canEdit = false,
     )
   }
 

--- a/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ListDetailsViewModel.kt
+++ b/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ListDetailsViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -98,7 +99,7 @@ class ListDetailsViewModel(
                   loadingMore = false,
                   refreshing = false,
                   error = null,
-                  canEdit = authRepository.tmdbAccount.first()?.username ==
+                  canEdit = authRepository.tmdbAccount.firstOrNull()?.username ==
                     listDetails.createdBy.username,
                 )
               }

--- a/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ListDetailsViewModel.kt
+++ b/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ListDetailsViewModel.kt
@@ -5,6 +5,7 @@ package com.divinelink.feature.lists.details
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.divinelink.core.commons.onError
+import com.divinelink.core.data.auth.AuthRepository
 import com.divinelink.core.data.list.ListRepository
 import com.divinelink.core.domain.list.FetchListDetailsUseCase
 import com.divinelink.core.domain.list.FetchListParameters
@@ -26,6 +27,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -33,6 +35,7 @@ class ListDetailsViewModel(
   route: ListDetailsRoute,
   private val fetchListDetailsUseCase: FetchListDetailsUseCase,
   private val repository: ListRepository,
+  private val authRepository: AuthRepository,
 ) : ViewModel() {
 
   private val _uiState: MutableStateFlow<ListDetailsUiState> = MutableStateFlow(
@@ -95,6 +98,8 @@ class ListDetailsViewModel(
                   loadingMore = false,
                   refreshing = false,
                   error = null,
+                  canEdit = authRepository.tmdbAccount.first()?.username ==
+                    listDetails.createdBy.username,
                 )
               }
             }

--- a/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ui/ListDetailsScreen.kt
+++ b/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ui/ListDetailsScreen.kt
@@ -130,7 +130,7 @@ fun AnimatedVisibilityScope.ListDetailsScreen(
     },
     floatingActionButton = {
       AnimatedVisibility(
-        visible = !uiState.multipleSelectMode,
+        visible = !uiState.multipleSelectMode && uiState.canEdit,
         enter = fadeIn(tween(easing = EaseIn)),
         exit = fadeOut(tween(easing = EaseOut)),
       ) {

--- a/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ui/provider/ListDetailsUiStateParameterProvider.kt
+++ b/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ui/provider/ListDetailsUiStateParameterProvider.kt
@@ -28,6 +28,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       snackbarMessage = null,
       selectedMedia = emptyList(),
       multipleSelectMode = false,
+      canEdit = false,
     ),
     ListDetailsUiState(
       id = 1,
@@ -44,6 +45,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       snackbarMessage = null,
       selectedMedia = emptyList(),
       multipleSelectMode = false,
+      canEdit = false,
     ),
     ListDetailsUiState(
       id = 1,
@@ -58,6 +60,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       snackbarMessage = null,
       selectedMedia = emptyList(),
       multipleSelectMode = false,
+      canEdit = false,
     ),
     ListDetailsUiState(
       id = 1,
@@ -72,6 +75,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       snackbarMessage = null,
       selectedMedia = emptyList(),
       multipleSelectMode = false,
+      canEdit = false,
     ),
     ListDetailsUiState(
       id = 1,
@@ -88,6 +92,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       snackbarMessage = null,
       selectedMedia = emptyList(),
       multipleSelectMode = false,
+      canEdit = false,
     ),
     ListDetailsUiState(
       id = 1,
@@ -104,6 +109,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       snackbarMessage = null,
       selectedMedia = emptyList(),
       multipleSelectMode = false,
+      canEdit = false,
     ),
     ListDetailsUiState(
       id = 1,
@@ -118,6 +124,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       snackbarMessage = null,
       selectedMedia = emptyList(),
       multipleSelectMode = false,
+      canEdit = false,
     ),
     ListDetailsUiState(
       id = 1,
@@ -132,6 +139,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       snackbarMessage = null,
       selectedMedia = emptyList(),
       multipleSelectMode = false,
+      canEdit = false,
     ),
     ListDetailsUiState(
       id = 1,
@@ -149,6 +157,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       snackbarMessage = null,
       selectedMedia = emptyList(),
       multipleSelectMode = false,
+      canEdit = false,
     ),
     ListDetailsUiState(
       id = 1,
@@ -163,6 +172,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       snackbarMessage = null,
       selectedMedia = emptyList(),
       multipleSelectMode = false,
+      canEdit = false,
     ),
     ListDetailsUiState(
       id = 1,
@@ -178,6 +188,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       selectedMedia = MediaItemFactory.MoviesList()
         .take(2),
       multipleSelectMode = true,
+      canEdit = true,
     ),
     ListDetailsUiState(
       id = 1,
@@ -193,6 +204,7 @@ class ListDetailsUiStateParameterProvider : PreviewParameterProvider<ListDetails
       selectedMedia = MediaItemFactory.MoviesList()
         .take(2),
       multipleSelectMode = true,
+      canEdit = true,
     ),
   )
 }


### PR DESCRIPTION
### Summary

Fixes an [issue](https://github.com/Divinelink/scenepeek-android/issues/282) where the user would get "Something went wrong" if they opened a list details deeplink. The issue was the `AuthTMDBClient` wouldn't pass a bearer auth token, resulting in a 401 api response. 

Additionally, handles the case where the `Edit` FAB button on a list should not be displayed if the list does not belong to the logged in user. 