### PR TITLE
Prevent discover fetch when same filters are applied

### DIFF
--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/media/model/details/DetailsResponseApi.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/media/model/details/DetailsResponseApi.kt
@@ -124,9 +124,7 @@ fun DetailsResponseApi.toDomainMedia(selectedRegion: Country?): MediaDetails = w
   is DetailsResponseApi.TV -> this.toDomainTVShow()
 }
 
-private fun DetailsResponseApi.Movie.toDomainMovie(
-  selectedRegion: Country?,
-): MediaDetails = Movie(
+private fun DetailsResponseApi.Movie.toDomainMovie(selectedRegion: Country?): MediaDetails = Movie(
   id = this.id,
   posterPath = this.posterPath ?: "",
   backdropPath = this.backdropPath ?: "",

--- a/feature/discover/src/commonMain/kotlin/com/divinelink/feature/discover/DiscoverUiState.kt
+++ b/feature/discover/src/commonMain/kotlin/com/divinelink/feature/discover/DiscoverUiState.kt
@@ -16,6 +16,7 @@ data class DiscoverUiState(
   val canFetchMore: Map<MediaType, Boolean>,
   val sortOption: Map<MediaType, SortOption>,
   val filters: Map<MediaType, MediaTypeFilters>,
+  val lastFilters: Map<MediaType, MediaTypeFilters>,
   val loadingMap: Map<MediaType, Boolean>,
 ) {
   companion object {
@@ -46,6 +47,10 @@ data class DiscoverUiState(
           MediaType.MOVIE to MediaTypeFilters.initial,
           MediaType.TV to MediaTypeFilters.initial,
         ),
+        lastFilters = mapOf(
+          MediaType.MOVIE to MediaTypeFilters.initial,
+          MediaType.TV to MediaTypeFilters.initial,
+        ),
         sortOption = emptyMap(),
         loadingMap = mapOf(
           MediaType.MOVIE to false,
@@ -58,6 +63,7 @@ data class DiscoverUiState(
   val selectedTab = tabs[selectedTabIndex]
   val selectedMedia = selectedTab.mediaType
   val currentFilters = filters[selectedTab.mediaType] ?: MediaTypeFilters.initial
+  val currentLastFilters = lastFilters[selectedTab.mediaType] ?: MediaTypeFilters.initial
   val canFetchMoreForSelectedTab = canFetchMore[selectedMedia] == true
   val isLoading = loadingMap[selectedMedia] == true
 }

--- a/feature/discover/src/commonMain/kotlin/com/divinelink/feature/discover/DiscoverViewModel.kt
+++ b/feature/discover/src/commonMain/kotlin/com/divinelink/feature/discover/DiscoverViewModel.kt
@@ -180,7 +180,7 @@ class DiscoverViewModel(
       .distinctUntilChanged()
       .onEach { sortMap ->
         _uiState.update { uiState -> uiState.copy(sortOption = sortMap) }
-        handleDiscoverMedia(reset = true)
+        handleDiscoverMedia(reset = true, fetchMore = false)
       }
       .launchIn(viewModelScope)
   }
@@ -188,7 +188,7 @@ class DiscoverViewModel(
   fun onAction(action: DiscoverAction) {
     when (action) {
       is DiscoverAction.OnSelectTab -> handleSelectTab(action)
-      DiscoverAction.DiscoverMedia -> handleDiscoverMedia(reset = true)
+      DiscoverAction.DiscoverMedia -> handleDiscoverMedia(reset = true, fetchMore = false)
       DiscoverAction.LoadMore -> handleLoadMore()
       DiscoverAction.ClearFilters -> handleClearFilters()
     }
@@ -199,7 +199,7 @@ class DiscoverViewModel(
       uuid = route.entryPointUuid,
       mediaType = _uiState.value.selectedMedia,
     )
-    handleDiscoverMedia(reset = true)
+    handleDiscoverMedia(reset = true, fetchMore = false)
   }
 
   private fun handleSelectTab(action: DiscoverAction.OnSelectTab) {
@@ -214,58 +214,65 @@ class DiscoverViewModel(
     val canFetchMore = _uiState.value.canFetchMore[selectedMedia] == true
 
     if (form is DiscoverForm.Data && canFetchMore) {
-      handleDiscoverMedia(reset = false)
+      handleDiscoverMedia(reset = false, fetchMore = canFetchMore)
     }
   }
 
-  private fun handleDiscoverMedia(reset: Boolean) {
+  private fun handleDiscoverMedia(
+    reset: Boolean,
+    fetchMore: Boolean,
+  ) {
     val mediaType = uiState.value.selectedMedia
     val currentFilters = uiState.value.currentFilters
+    val lastFilters = uiState.value.currentLastFilters
 
-    if (reset) {
-      _uiState.update { uiState ->
-        uiState.copy(
-          pages = uiState.pages + (uiState.selectedMedia to 1),
-          loadingMap = uiState.loadingMap + (uiState.selectedMedia to true),
-        )
-      }
-    }
-
-    if (currentFilters.hasSelectedFilters) {
-      discoverUseCase.invoke(
-        parameters = DiscoverParameters(
-          page = uiState.value.pages[uiState.value.selectedMedia] ?: 1,
-          sortOption = uiState.value.sortOption[uiState.value.selectedMedia]
-            ?: SortOption.defaultDiscoverSortOption,
-          mediaType = mediaType,
-          filters = currentFilters,
-        ),
-      )
-        .distinctUntilChanged()
-        .onEach { result ->
-          result.fold(
-            onSuccess = { response ->
-              updateUiOnSuccess(
-                reset = reset,
-                response = response,
-              )
-            },
-            onFailure = { error ->
-              updateUiOnFailure(
-                type = mediaType,
-                error = error,
-                reset = reset,
-              )
-            },
+    if (currentFilters != lastFilters || fetchMore) {
+      if (reset) {
+        _uiState.update { uiState ->
+          uiState.copy(
+            pages = uiState.pages + (uiState.selectedMedia to 1),
+            loadingMap = uiState.loadingMap + (uiState.selectedMedia to true),
           )
         }
-        .launchIn(viewModelScope)
-    } else {
-      _uiState.update { uiState ->
-        uiState.copy(
-          forms = uiState.forms.plus(uiState.selectedMedia to DiscoverForm.Initial),
-          loadingMap = uiState.loadingMap + (uiState.selectedMedia to false),
+      }
+
+      if (currentFilters.hasSelectedFilters) {
+        discoverUseCase.invoke(
+          parameters = DiscoverParameters(
+            page = uiState.value.pages[uiState.value.selectedMedia] ?: 1,
+            sortOption = uiState.value.sortOption[uiState.value.selectedMedia]
+              ?: SortOption.defaultDiscoverSortOption,
+            mediaType = mediaType,
+            filters = currentFilters,
+          ),
         )
+          .distinctUntilChanged()
+          .onEach { result ->
+            result.fold(
+              onSuccess = { response ->
+                updateUiOnSuccess(
+                  reset = reset,
+                  response = response,
+                  filters = currentFilters,
+                )
+              },
+              onFailure = { error ->
+                updateUiOnFailure(
+                  type = mediaType,
+                  error = error,
+                  reset = reset,
+                )
+              },
+            )
+          }
+          .launchIn(viewModelScope)
+      } else {
+        _uiState.update { uiState ->
+          uiState.copy(
+            forms = uiState.forms.plus(uiState.selectedMedia to DiscoverForm.Initial),
+            loadingMap = uiState.loadingMap + (uiState.selectedMedia to false),
+          )
+        }
       }
     }
   }
@@ -273,6 +280,7 @@ class DiscoverViewModel(
   private fun updateUiOnSuccess(
     reset: Boolean,
     response: UserDataResponse,
+    filters: MediaTypeFilters,
   ) {
     _uiState.update { uiState ->
       val data = (uiState.forms[response.type] as? DiscoverForm.Data)?.paginationData ?: mapOf(
@@ -294,6 +302,10 @@ class DiscoverViewModel(
         pages = uiState.pages + (response.type to response.page + 1),
         canFetchMore = uiState.canFetchMore + (response.type to response.canFetchMore),
         loadingMap = uiState.loadingMap + (uiState.selectedMedia to false),
+        lastFilters = uiState.filters.updateFilters(
+          mediaType = uiState.selectedTab.mediaType,
+          update = { filters },
+        ),
       )
     }
   }

--- a/feature/discover/src/commonMain/kotlin/com/divinelink/feature/discover/filters/SelectFilterViewModel.kt
+++ b/feature/discover/src/commonMain/kotlin/com/divinelink/feature/discover/filters/SelectFilterViewModel.kt
@@ -181,47 +181,51 @@ class SelectFilterViewModel(
         )
       }
 
-      repository.fetchGenres(mediaType).distinctUntilChanged().onEach { result ->
-        when (result) {
-          is Resource.Error -> _uiState.update {
-            val blankSlate = when (result.error) {
-              is AppException.Offline -> BlankSlateState.Offline
-              else -> BlankSlateState.Generic
+      repository
+        .fetchGenres(mediaType)
+        .distinctUntilChanged()
+        .onEach { result ->
+          when (result) {
+            is Resource.Error -> _uiState.update {
+              val blankSlate = when (result.error) {
+                is AppException.Offline -> BlankSlateState.Offline
+                else -> BlankSlateState.Generic
+              }
+
+              it.copy(
+                error = blankSlate,
+                loading = false,
+              )
             }
+            is Resource.Loading -> _uiState.update { uiState ->
+              val selected = (uiState.filterType as? FilterType.Searchable.Genres)?.selectedOptions
 
-            it.copy(
-              error = blankSlate,
-              loading = false,
-            )
-          }
-          is Resource.Loading -> _uiState.update { uiState ->
-            val selected = (uiState.filterType as? FilterType.Searchable.Genres)?.selectedOptions
+              uiState.copy(
+                loading = false,
+                filterType = FilterType.Searchable.Genres(
+                  options = result.data ?: emptyList(),
+                  selectedOptions = selected ?: emptyList(),
+                  query = null,
+                ),
+                error = null,
+              )
+            }
+            is Resource.Success -> _uiState.update { uiState ->
+              val selected = (uiState.filterType as? FilterType.Searchable.Genres)?.selectedOptions
 
-            uiState.copy(
-              loading = false,
-              filterType = FilterType.Searchable.Genres(
-                options = result.data ?: emptyList(),
-                selectedOptions = selected ?: emptyList(),
-                query = null,
-              ),
-              error = null,
-            )
-          }
-          is Resource.Success -> _uiState.update { uiState ->
-            val selected = (uiState.filterType as? FilterType.Searchable.Genres)?.selectedOptions
-
-            uiState.copy(
-              loading = false,
-              filterType = FilterType.Searchable.Genres(
-                options = result.data,
-                selectedOptions = selected ?: emptyList(),
-                query = null,
-              ),
-              error = null,
-            )
+              uiState.copy(
+                loading = false,
+                filterType = FilterType.Searchable.Genres(
+                  options = result.data,
+                  selectedOptions = selected ?: emptyList(),
+                  query = null,
+                ),
+                error = null,
+              )
+            }
           }
         }
-      }.launchIn(viewModelScope)
+        .launchIn(viewModelScope)
     }
   }
 

--- a/feature/onboarding/src/commonMain/composeResources/values/strings.xml
+++ b/feature/onboarding/src/commonMain/composeResources/values/strings.xml
@@ -68,4 +68,5 @@
   <string name="v46_improve_ui_for_large_screens">- Improve UI and compatibility for large screens, tablets and landscape mode</string>
 
   <string name="v47_movie_release_dates">- Add movie release dates showing premiere, theatrical, digital and physical format information</string>
+  <string name="v47_discover_fetch_only_with_different_filters">- Only fetch new discover content when the filter settings are different from the previous search</string>
 </resources>

--- a/feature/onboarding/src/commonMain/kotlin/com/divinelink/feature/onboarding/manager/IntroSections.kt
+++ b/feature/onboarding/src/commonMain/kotlin/com/divinelink/feature/onboarding/manager/IntroSections.kt
@@ -54,6 +54,7 @@ import com.divinelink.feature.onboarding.resources.v41_add_version_checker
 import com.divinelink.feature.onboarding.resources.v44_add_missing_www_subdomain_on_share_urls
 import com.divinelink.feature.onboarding.resources.v44_fix_version_checker
 import com.divinelink.feature.onboarding.resources.v46_improve_ui_for_large_screens
+import com.divinelink.feature.onboarding.resources.v47_discover_fetch_only_with_different_filters
 import com.divinelink.feature.onboarding.resources.v47_movie_release_dates
 import com.divinelink.feature.onboarding.resources.Res as R
 
@@ -238,6 +239,8 @@ object IntroSections {
     IntroSection.WhatsNew("v0.31.0"),
     IntroSection.SecondaryHeader.Added,
     IntroSection.Text(UIText.ResourceText(R.string.v47_movie_release_dates)),
+    IntroSection.SecondaryHeader.Fixed,
+    IntroSection.Text(UIText.ResourceText(R.string.v47_discover_fetch_only_with_different_filters)),
   )
 
   /**


### PR DESCRIPTION
### Summary

Fixed an issue where discover would re-fetch the same request even if the filters where the same. This essentially created unnecessary request, but would also reset the pages when the user opened a modal bottom sheet, to select a filter, and dismiss it without updating the filters.  