### PR TITLE
Migrate deprecated back handler

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -105,7 +105,6 @@ dependencies {
   // Testing Libs
   testImplementation(projects.core.testing)
 
-  testImplementation(libs.androidx.compose.ui.test)
   testImplementation(libs.robolectric)
   testImplementation(libs.ui.automator)
   debugImplementation(libs.androidx.test.ktx)

--- a/app/src/commonMain/kotlin/com/divinelink/scenepeek/di/NavigationModule.kt
+++ b/app/src/commonMain/kotlin/com/divinelink/scenepeek/di/NavigationModule.kt
@@ -2,10 +2,12 @@ package com.divinelink.scenepeek.di
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.platform.testTag
 import androidx.navigation3.scene.DialogSceneStrategy
 import androidx.navigation3.ui.LocalNavAnimatedContentScope
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
 import com.divinelink.core.model.media.decodeToMediaItem
 import com.divinelink.core.navigation.Navigator
 import com.divinelink.core.navigation.route.Navigation
@@ -162,9 +164,11 @@ val navigationModule = module {
 
   navigation<Navigation.Onboarding.FullScreenRoute> {
     val navigator = get<Navigator>()
-    BackHandler(enabled = true) {
-      // Disable back button
-    }
+    NavigationBackHandler(
+      state = rememberNavigationEventState(NavigationEventInfo.None),
+      isBackEnabled = false,
+      onBackCompleted = {},
+    )
 
     IntroModalBottomSheet(
       modifier = Modifier.testTag(TestTags.Onboarding.FULLSCREEN),
@@ -174,9 +178,11 @@ val navigationModule = module {
 
   navigation<Navigation.Onboarding.ModalRoute>(metadata = DialogSceneStrategy.dialog()) {
     val navigator = get<Navigator>()
-    BackHandler(enabled = true) {
-      // Disable back button
-    }
+    NavigationBackHandler(
+      state = rememberNavigationEventState(NavigationEventInfo.None),
+      isBackEnabled = false,
+      onBackCompleted = {},
+    )
 
     IntroModalBottomSheet(
       modifier = Modifier.testTag(TestTags.Onboarding.MODAL),

--- a/build-logic/convention/src/main/kotlin/ComposeMultiplatformPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/ComposeMultiplatformPlugin.kt
@@ -41,7 +41,6 @@ class ComposeMultiplatformPlugin : Plugin<Project> {
 
           api(libs.compose.multiplatform.navigation3)
           api(libs.lifecycle.multiplatform.viewmodel.navigation3)
-          implementation(libs.compose.multiplatform.backhandler)
         }
 
         androidMain.dependencies {

--- a/feature/details/src/commonMain/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
+++ b/feature/details/src/commonMain/kotlin/com/divinelink/feature/details/media/ui/DetailsScreen.kt
@@ -14,9 +14,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.platform.testTag
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
 import com.divinelink.core.domain.components.SwitchViewButtonViewModel
 import com.divinelink.core.model.media.MediaItem
 import com.divinelink.core.navigation.route.Navigation
@@ -45,13 +47,17 @@ fun DetailsScreen(
   var showAllRatingBottomSheet by rememberSaveable { mutableStateOf(false) }
   var openRateBottomSheet by rememberSaveable { mutableStateOf(false) }
 
-  BackHandler {
-    if (videoUrl.isNullOrEmpty()) {
-      onNavigate(Navigation.Back)
-    } else {
-      videoUrl = null
-    }
-  }
+  NavigationBackHandler(
+    state = rememberNavigationEventState(NavigationEventInfo.None),
+    isBackEnabled = true,
+    onBackCompleted = {
+      if (videoUrl.isNullOrEmpty()) {
+        onNavigate(Navigation.Back)
+      } else {
+        videoUrl = null
+      }
+    },
+  )
 
   LaunchedEffect(viewState.navigateToLogin) {
     viewState.navigateToLogin?.let {

--- a/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ui/ListScrollableContent.kt
+++ b/feature/lists/src/commonMain/kotlin/com/divinelink/feature/lists/details/ui/ListScrollableContent.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.backhandler.BackHandler
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
@@ -37,6 +36,9 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.navigationevent.NavigationEventInfo
+import androidx.navigationevent.compose.NavigationBackHandler
+import androidx.navigationevent.compose.rememberNavigationEventState
 import com.divinelink.core.designsystem.theme.LocalBottomNavigationPadding
 import com.divinelink.core.designsystem.theme.dimensions
 import com.divinelink.core.designsystem.theme.mediaCardSize
@@ -112,9 +114,11 @@ fun ListScrollableContent(
     onUpdateToolbarProgress(firstItemScrollProgress)
   }
 
-  BackHandler(enabled = state.multipleSelectMode) {
-    action.invoke(ListDetailsAction.OnDismissMultipleSelect)
-  }
+  NavigationBackHandler(
+    state = rememberNavigationEventState(NavigationEventInfo.None),
+    isBackEnabled = state.multipleSelectMode,
+    onBackCompleted = { action.invoke(ListDetailsAction.OnDismissMultipleSelect) },
+  )
 
   scrollState.EndlessScrollHandler(
     buffer = 4,

--- a/feature/onboarding/src/commonMain/kotlin/com/divinelink/feature/onboarding/manager/IntroSections.kt
+++ b/feature/onboarding/src/commonMain/kotlin/com/divinelink/feature/onboarding/manager/IntroSections.kt
@@ -59,6 +59,7 @@ import com.divinelink.feature.onboarding.resources.v47_discover_fetch_only_with_
 import com.divinelink.feature.onboarding.resources.v47_movie_release_dates
 import com.divinelink.feature.onboarding.resources.v48_fix_discover_sorting_options
 import com.divinelink.feature.onboarding.resources.v48_fix_tmdb_auth_issue
+import com.divinelink.feature.onboarding.resources.v49_add_custom_remote_config
 import com.divinelink.feature.onboarding.resources.Res as R
 
 object IntroSections {
@@ -259,7 +260,7 @@ object IntroSections {
     IntroSection.Header(UIText.ResourceText(R.string.feature_onboarding_changelog)),
     IntroSection.WhatsNew("v0.31.2"),
     IntroSection.SecondaryHeader.Added,
-    IntroSection.Text(UIText.ResourceText(R.string.v48_fix_discover_sorting_options)),
+    IntroSection.Text(UIText.ResourceText(R.string.v49_add_custom_remote_config)),
   )
 
   /**
@@ -281,5 +282,6 @@ object IntroSections {
     46 to v46,
     47 to v47,
     48 to v48,
+    49 to v49,
   )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,6 @@ kotest = "6.1.11"
 
 # UI
 robolectric = "4.16.1"
-androidx-compose-ui-test = "1.10.6"
 ui-automator = "2.3.0"
 
 # Mockers
@@ -108,7 +107,6 @@ compose-multiplatform-ui-tooling-preview = { module = "org.jetbrains.compose.ui:
 compose-multiplatform-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "compose-multiplatform" }
 compose-multiplatform-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "compose-multiplatform" }
 compose-multiplatform-navigation3 = { module = "org.jetbrains.androidx.navigation3:navigation3-ui", version.ref = "navigation3" }
-compose-multiplatform-backhandler = { group = "org.jetbrains.compose.ui", name = "ui-backhandler", version.ref = "compose-multiplatform" }
 compose-shimmer = { group = "com.valentinilk.shimmer", name = "compose-shimmer", version.ref = "compose-shimmer" }
 compose-colorpicker = { group = "com.github.skydoves", name = "colorpicker-compose", version.ref = "compose-colorpicker" }
 material-kolor = { group = "com.materialkolor", name = "material-kolor", version.ref = "materialkolor" }
@@ -173,7 +171,6 @@ compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-mani
 
 # UI
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
-androidx-compose-ui-test = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidx-compose-ui-test" }
 ui-automator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "ui-automator" }
 
 # Mockers


### PR DESCRIPTION
### Summary

- Replace deprecated `BackHandler` with `NavigationBackHandler`
- Remove `compose-multiplatform-backhandler` dependency