### PR TITLE
Clean up duplicate strings and properly mark untranslatable

### DIFF
--- a/core/ui/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values-de/strings.xml
@@ -81,7 +81,6 @@
     <string name="core_ui_clear_data_series_description">Das wird alle Daten dieser Serie, inklusive sämtlicher Anfragen, unwiderruflich löschen. Wenn dieses Element in deiner Jellyfn Bibliothek existiert, werden die Medieninformationen während des nächsten Scans wieder erstellt.</string>
     <string name="core_ui_loading">Lädt…</string>
     <string name="core_ui_load_more">Mehr laden…</string>
-    <string name="popular_movie__rating">Bewertung</string>
     <string name="core_ui_toolbar_search_placeholder">Suche nach einer Serie, einem Film, etc.</string>
     <string name="core_ui_percentage">%1$s%</string>
     <string name="core_ui_metascore">Metascore</string>
@@ -105,7 +104,6 @@
     <string name="core_ui_cancel_request">Anfrage stornieren</string>
     <string name="core_ui_delete_request">Anfrage löschen</string>
     <string name="core_ui_delete_request_confirmation_text">Bist du sicher, dass du diese Anfrage löschen willst?</string>
-    <string name="core_ui_clear_media_title">Daten löschen</string>
     <string name="core_ui_read_more">Mehr lesen</string>
     <string name="core_ui_show_more">Mehr anzeigen</string>
     <string name="core_ui_show_less">Weniger anzeigen</string>

--- a/core/ui/src/commonMain/composeResources/values/strings.xml
+++ b/core/ui/src/commonMain/composeResources/values/strings.xml
@@ -47,10 +47,6 @@
 
   <string name="core_ui_general_error_title">An error has occurred</string>
 
-  <string name="details__director_title">Director</string>
-  <string name="details__cast_title">Cast</string>
-  <string name="core_ui_series_cast_title">Series Cast</string>
-
   <string name="core_ui_director">Director</string>
   <string name="core_ui_screenplay">Screenplay</string>
   <string name="core_ui_novel">Novel</string>
@@ -78,6 +74,11 @@
   <string name="core_ui_tv_shows">tv shows</string>
   <string name="core_ui_people">people</string>
 
+  <string name="movies">Movies</string>
+  <string name="tv_shows">TV Shows</string>
+  <string name="seasons">Seasons</string>
+  <string name="episodes">Episodes</string>
+
   <string name="core_ui_media">Media</string>
   <string name="core_ui_remove_from_radarr">Remove from Radarr</string>
   <string name="core_ui_remove_from_radarr_description">This will irreversibly remove this movie from Radarr, including all files.</string>
@@ -91,14 +92,11 @@
   <string name="core_ui_clear_data_series_description">This will irreversibly remove all data for this series, including any requests. If this item exists in your Jellyfin library, the media information will be recreated during the next scan.</string>
 
   <string name="core_ui_loading">Loading…</string>
-  <string name="core_ui_load_more">Loading more…</string>
-
-  <string name="popular_movie__rating">Rating</string>
 
   <string name="core_ui_toolbar_search_placeholder">Search for a show, movie, etc.</string>
 
-  <string name="core_ui_percentage">%1$s%</string>
-  <string name="core_ui_metascore">Metascore</string>
+  <string name="core_ui_percentage" translatable="false">%1$s%</string>
+  <string name="core_ui_metascore" translatable="false">Metascore</string>
 
   <string name="core_ui_episodes">Episodes</string>
   <string name="core_ui_status">Status</string>
@@ -125,24 +123,20 @@
   <string name="core_ui_delete_request">Delete request</string>
   <string name="core_ui_delete_request_confirmation_text">Are you sure you want to delete this request?</string>
 
-  <string name="core_ui_clear_media_title">Clear data</string>
-
-
   <string name="core_ui_read_more">Read more</string>
   <string name="core_ui_show_more">Show more</string>
   <string name="core_ui_show_less">Show less</string>
 
-  <string name="core_ui_view">View</string>
   <string name="core_ui_filter">Filter</string>
 
   <string name="core_ui_offline_title">You are offline</string>
   <string name="core_ui_offline_description">Please connect to the internet and try again.</string>
 
-  <string name="core_ui_error_generic_title">Something when wrong</string>
+  <string name="core_ui_error_generic_title">Something went wrong</string>
   <string name="core_ui_error_generic_description">Please try again.</string>
   <string name="core_ui_error_contact_description">Please try again. If the problem persists, please contact the developer.</string>
 
-  <string name="core_ui_jellyseerr_session_expired">Your Jellyseerr session has expired. Please login again.</string>
+  <string name="core_ui_jellyseerr_session_expired">Your Seerr session has expired. Please log in again.</string>
 
   <string name="core_ui_tmdb_user_score">User\nScore</string>
 

--- a/core/ui/src/commonMain/kotlin/com/divinelink/core/ui/blankslate/BlankSlateState.kt
+++ b/core/ui/src/commonMain/kotlin/com/divinelink/core/ui/blankslate/BlankSlateState.kt
@@ -9,8 +9,8 @@ import com.divinelink.core.ui.resources.core_ui_error_contact_description
 import com.divinelink.core.ui.resources.core_ui_error_generic_description
 import com.divinelink.core.ui.resources.core_ui_error_generic_title
 import com.divinelink.core.ui.resources.core_ui_login_title
+import com.divinelink.core.ui.resources.core_ui_not_connected
 import com.divinelink.core.ui.resources.core_ui_offline_description
-import com.divinelink.core.ui.resources.core_ui_offline_title
 import com.divinelink.core.ui.resources.core_ui_retry
 import com.divinelink.core.ui.resources.no_connection
 import org.jetbrains.compose.resources.DrawableResource
@@ -23,7 +23,7 @@ sealed class BlankSlateState(
 ) {
   data object Offline : BlankSlateState(
     icon = UiDrawable.no_connection,
-    title = UIText.ResourceText(UiString.core_ui_offline_title),
+    title = UIText.ResourceText(UiString.core_ui_not_connected),
     description = UIText.ResourceText(UiString.core_ui_offline_description),
     retryText = UIText.ResourceText(UiString.core_ui_retry),
   )

--- a/feature/details/src/commonMain/composeResources/values/strings.xml
+++ b/feature/details/src/commonMain/composeResources/values/strings.xml
@@ -30,7 +30,7 @@
   <string name="feature_details_person_credits_known_for_section">Known For</string>
 
   <string name="feature_details_person_credits_department">Department</string>
-  <string name="feature_details_person_credits_department_size">%1$s (%2$s)</string>
+  <string name="feature_details_person_credits_department_size" translatable="false">%1$s (%2$s)</string>
 
   <string name="feature_details_filter_sort_release_date">Release date</string>
 
@@ -77,7 +77,6 @@
   <string name="feature_details_information_runtime">Runtime</string>
   <string name="feature_details_information_original_language">Original language</string>
   <string name="feature_details_information_budget">Budget</string>
-  <string name="feature_details_information_last_air_date">Last air date</string>
   <string name="feature_details_information_next_episode_air_date">Next episode air date</string>
   <string name="feature_details_information_seasons">Seasons</string>
 

--- a/feature/details/src/commonMain/kotlin/com/divinelink/feature/details/media/ui/components/TvInformationSection.kt
+++ b/feature/details/src/commonMain/kotlin/com/divinelink/feature/details/media/ui/components/TvInformationSection.kt
@@ -17,9 +17,9 @@ import com.divinelink.core.ui.UiString
 import com.divinelink.core.ui.extension.localizeFull
 import com.divinelink.core.ui.resources.core_ui_aired_episodes
 import com.divinelink.core.ui.resources.core_ui_first_air_date
+import com.divinelink.core.ui.resources.core_ui_last_air_date
 import com.divinelink.feature.details.resources.Res
 import com.divinelink.feature.details.resources.feature_details_information
-import com.divinelink.feature.details.resources.feature_details_information_last_air_date
 import com.divinelink.feature.details.resources.feature_details_information_next_episode_air_date
 import com.divinelink.feature.details.resources.feature_details_information_original_language
 import com.divinelink.feature.details.resources.feature_details_information_original_title
@@ -63,7 +63,7 @@ fun TvInformationSection(
 
     information.lastAirDate.toLocalDate().localizeFull()?.let { airDate ->
       SimpleInformationRow(
-        title = stringResource(Res.string.feature_details_information_last_air_date),
+        title = stringResource(UiString.core_ui_last_air_date),
         data = airDate,
       )
     }

--- a/feature/onboarding/src/androidHostTest/kotlin/com/divinelink/feature/onboarding/ui/IntroModalBottomSheetTest.kt
+++ b/feature/onboarding/src/androidHostTest/kotlin/com/divinelink/feature/onboarding/ui/IntroModalBottomSheetTest.kt
@@ -42,7 +42,7 @@ class IntroModalBottomSheetTest : ComposeTest() {
     }
 
     onNodeWithText("TMDB").assertIsDisplayed()
-    onNodeWithText("Jellyseerr").assertIsDisplayed()
+    onNodeWithText("Seerr").assertIsDisplayed()
   }
 
   @Test
@@ -97,7 +97,7 @@ class IntroModalBottomSheetTest : ComposeTest() {
         viewModel = viewModel,
       )
     }
-    onNodeWithText("Jellyseerr").performClick()
+    onNodeWithText("Seerr").performClick()
 
     jellyseerrRoute shouldBe Navigation.JellyseerrSettingsRoute(withNavigationBar = false)
   }

--- a/feature/onboarding/src/commonMain/composeResources/values/strings.xml
+++ b/feature/onboarding/src/commonMain/composeResources/values/strings.xml
@@ -5,15 +5,16 @@
   <string name="feature_onboarding_skip">Skip</string>
 
   <string name="feature_onboarding_welcome_page_title">Welcome to ScenePeek</string>
-  <string name="feature_onboarding_welcome_page_description">A free and open-source client for TMDB &amp; Jellyseerr</string>
+  <string name="feature_onboarding_welcome_page_description">A free and open-source client for TMDB &amp; Seerr</string>
 
+  <!-- %1$s is the app name, %2$s is the new version -->
   <string name="feature_onboarding_whats_new_title">What's new in %1$s for %2$s</string>
 
-  <string name="feature_onboarding_tmdb_page_title">TMDB</string>
+  <string name="feature_onboarding_tmdb_page_title" translatable="false">TMDB</string>
   <string name="feature_onboarding_tmdb_page_description">Connect your TMDB account to access your watchlist, ratings, lists and more.</string>
 
-  <string name="feature_onboarding_jellyseerr_page_title">Jellyseerr</string>
-  <string name="feature_onboarding_jellyseerr_page_description">Connect to your Jellyseerr instance to request movies and TV shows instantly.</string>
+  <string name="feature_onboarding_jellyseerr_page_title" translatable="false">Seerr</string>
+  <string name="feature_onboarding_jellyseerr_page_description">Connect to your Seerr instance to request movies and TV shows instantly.</string>
 
   <string name="feature_onboarding_link_handling_page_title">IMDb &amp; TMDB Link Handling</string>
   <string name="feature_onboarding_link_handling_page_description"><![CDATA[ScenePeek can open <strong>URLs</strong> from <strong>IMDb</strong> & <strong>TMDB</strong> in the app. This can be useful for opening links to movies, TV shows and people directly in the app.]]></string>

--- a/feature/search/src/commonTest/kotlin/com/divinelink/feature/search/SearchContentTest.kt
+++ b/feature/search/src/commonTest/kotlin/com/divinelink/feature/search/SearchContentTest.kt
@@ -19,8 +19,8 @@ import com.divinelink.core.testing.uiTest
 import com.divinelink.core.ui.TestTags
 import com.divinelink.core.ui.UiString
 import com.divinelink.core.ui.components.MOVIE_CARD_ITEM_TAG
+import com.divinelink.core.ui.resources.core_ui_not_connected
 import com.divinelink.core.ui.resources.core_ui_offline_description
-import com.divinelink.core.ui.resources.core_ui_offline_title
 import com.divinelink.feature.search.resources.Res
 import com.divinelink.feature.search.resources.feature_search__initial_description
 import com.divinelink.feature.search.resources.search__empty_result_description
@@ -195,7 +195,7 @@ class SearchContentTest : ComposeTest() {
 
     onNodeWithTag(TestTags.BLANK_SLATE).assertIsDisplayed()
     onNodeWithText(
-      getString(UiString.core_ui_offline_title),
+      getString(UiString.core_ui_not_connected),
     ).assertIsDisplayed()
     onNodeWithText(
       getString(UiString.core_ui_offline_description),

--- a/feature/settings/src/androidHostTest/kotlin/com/divinelink/feature/settings/app/about/AboutSettingsScreenTest.kt
+++ b/feature/settings/src/androidHostTest/kotlin/com/divinelink/feature/settings/app/about/AboutSettingsScreenTest.kt
@@ -167,7 +167,7 @@ class AboutSettingsScreenTest : ComposeTest() {
     val url = getString(R.string.feature_settings_about__repository_url)
     navigationRoute shouldBe Navigation.WebViewRoute(
       url = url,
-      title = "Github",
+      title = "GitHub",
     )
   }
 
@@ -203,7 +203,7 @@ class AboutSettingsScreenTest : ComposeTest() {
 
     navigationRoute shouldBe Navigation.WebViewRoute(
       url = url,
-      title = "Github",
+      title = "GitHub",
     )
   }
 }

--- a/feature/settings/src/androidHostTest/kotlin/com/divinelink/feature/settings/app/details/DetailsPreferencesSettingsScreenTest.kt
+++ b/feature/settings/src/androidHostTest/kotlin/com/divinelink/feature/settings/app/details/DetailsPreferencesSettingsScreenTest.kt
@@ -15,9 +15,9 @@ import com.divinelink.core.testing.setVisibilityScopeContent
 import com.divinelink.core.testing.uiTest
 import com.divinelink.core.testing.usecase.TestMediaRatingPreferenceUseCase
 import com.divinelink.core.ui.TestTags
-import com.divinelink.feature.settings.resources.Res
-import com.divinelink.feature.settings.resources.feature_settings_movie_rating_preference
-import com.divinelink.feature.settings.resources.feature_settings_tv_rating_preference
+import com.divinelink.core.ui.UiString
+import com.divinelink.core.ui.resources.movies
+import com.divinelink.core.ui.resources.tv_shows
 import org.jetbrains.compose.resources.getString
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -53,12 +53,11 @@ class DetailsPreferencesSettingsScreenTest : ComposeTest() {
     onNodeWithText(RatingSource.IMDB.value).assertIsDisplayed()
 
     onNodeWithTag(TestTags.LAZY_COLUMN).performScrollToNode(
-      hasText(getString(Res.string.feature_settings_tv_rating_preference)),
+      hasText(getString(UiString.tv_shows)),
     )
 
-    onNodeWithText(
-      getString(Res.string.feature_settings_movie_rating_preference),
-    ).assertIsDisplayed()
+    onNodeWithText(getString(UiString.movies))
+      .assertIsDisplayed()
       .performClick()
 
     onNodeWithTag(
@@ -91,7 +90,7 @@ class DetailsPreferencesSettingsScreenTest : ComposeTest() {
 
     onNodeWithText(RatingSource.IMDB.value).assertIsDisplayed()
 
-    onNodeWithText(getString(Res.string.feature_settings_tv_rating_preference)).assertIsDisplayed()
+    onNodeWithText(getString(UiString.tv_shows)).assertIsDisplayed()
       .performClick()
 
     onNodeWithTag(

--- a/feature/settings/src/commonMain/composeResources/values/strings.xml
+++ b/feature/settings/src/commonMain/composeResources/values/strings.xml
@@ -87,9 +87,9 @@
   <string name="feature_settings_about__privacy_policy">Privacy Policy</string>
   <string name="feature_settings_about__privacy_policy_url" translatable="false">https://www.scenepeek.app/privacy</string>
 
-  <string name="feature_settings_about__github" translatable="false">Github</string>
+  <string name="feature_settings_about__github" translatable="false">GitHub</string>
   <string name="feature_settings_about__version">Version %1$s</string>
-  <string name="feature_settings_about__developer_github_url">https://github.com/%1$s</string>
+  <string name="feature_settings_about__developer_github_url" translatable="false">https://github.com/%1$s</string>
   <string name="feature_settings_about__repository_url" translatable="false">https://github.com/Divinelink/scenepeek-android</string>
   <string name="feature_settings_about__tmdb_endorsement">This product uses the TMDB API but is not endorsed or certified by TMDB.</string>
 
@@ -106,20 +106,15 @@
   <string name="feature_settings_streaming_services_subtitle">Display streaming services information.</string>
   <string name="feature_settings_ratings">Ratings</string>
   <string name="feature_settings_ratings_summary">Choose the rating system you want to use.\nIt will be displayed in the details screen of movies and TV shows.</string>
-  <string name="feature_settings_movie_rating_preference">Movies</string>
-  <string name="feature_settings_tv_rating_preference">TV Shows</string>
-  <string name="feature_settings_episodes_rating_preference">Episodes</string>
-  <string name="feature_settings_seasons_rating_preference">Seasons</string>
 
-  <string name="support_email">support@scenepeek.app</string>
-  <string name="seerr_support_email_subject">Trouble connecting to Seerr</string>
-  <string name="seerr_support_email_body">"Please specify your login method, server versions and attach the error logs to help identify the issue."\n\nSeerr version: (enter your Seerr server version)\nJellyfin version: (enter your Jellyfin version if applicable)\n%1$s</string>
+  <string name="support_email" translatable="false">support@scenepeek.app</string>
+  <string name="seerr_support_email_subject" translatable="false">Trouble connecting to Seerr</string>
+  <string name="seerr_support_email_body" translatable="false">"Please specify your login method, server versions and attach the error logs to help identify the issue."\n\nSeerr version: (enter your Seerr server version)\nJellyfin version: (enter your Jellyfin version if applicable)\n%1$s</string>
 
   <string name="seerr_login_info_placeholder_pt1">This is an experimental feature.\nIf you have trouble connecting, please get in contact at </string>
   <string name="seerr_login_info_placeholder_pt2"> to troubleshoot the issue.</string>
 
   <!-- preferences.xml -->
-  <string name="preferences__none">None</string>
   <string name="preferences__account">Account</string>
   <string name="preferences__appearance">Appearance</string>
   <string name="feature_settings_details_preferences">Details preferences</string>

--- a/feature/settings/src/commonMain/kotlin/com/divinelink/feature/settings/app/details/DetailsPreferencesSettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/com/divinelink/feature/settings/app/details/DetailsPreferencesSettingsScreen.kt
@@ -11,19 +11,20 @@ import com.divinelink.core.designsystem.component.ScenePeekLazyColumn
 import com.divinelink.core.model.details.rating.MediaRatingSource
 import com.divinelink.core.model.locale.Country
 import com.divinelink.core.ui.TestTags
+import com.divinelink.core.ui.UiString
+import com.divinelink.core.ui.resources.movies
+import com.divinelink.core.ui.resources.tv_shows
 import com.divinelink.feature.settings.components.SettingsRadioPrefItem
 import com.divinelink.feature.settings.components.SettingsScaffold
 import com.divinelink.feature.settings.components.SettingsSwitchItem
 import com.divinelink.feature.settings.components.SettingsTextItem
 import com.divinelink.feature.settings.resources.Res
 import com.divinelink.feature.settings.resources.feature_settings_details_preferences
-import com.divinelink.feature.settings.resources.feature_settings_movie_rating_preference
 import com.divinelink.feature.settings.resources.feature_settings_ratings
 import com.divinelink.feature.settings.resources.feature_settings_ratings_summary
 import com.divinelink.feature.settings.resources.feature_settings_region
 import com.divinelink.feature.settings.resources.feature_settings_streaming_services
 import com.divinelink.feature.settings.resources.feature_settings_streaming_services_subtitle
-import com.divinelink.feature.settings.resources.feature_settings_tv_rating_preference
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -76,7 +77,7 @@ fun DetailPreferencesSettingsScreen(
 
       item {
         SettingsRadioPrefItem(
-          title = stringResource(Res.string.feature_settings_movie_rating_preference),
+          title = stringResource(UiString.movies),
           selectedOption = uiState.movieSource,
           displayText = { it.value },
           listItems = MediaRatingSource.Movie.options,
@@ -88,7 +89,7 @@ fun DetailPreferencesSettingsScreen(
 
       item {
         SettingsRadioPrefItem(
-          title = stringResource(Res.string.feature_settings_tv_rating_preference),
+          title = stringResource(UiString.tv_shows),
           selectedOption = uiState.tvSource,
           displayText = { it.value },
           listItems = MediaRatingSource.TVShow.options,

--- a/feature/user-data/src/androidHostTest/kotlin/com/divinelink/feature/user/data/UserDataScreenTest.kt
+++ b/feature/user-data/src/androidHostTest/kotlin/com/divinelink/feature/user/data/UserDataScreenTest.kt
@@ -33,8 +33,8 @@ import com.divinelink.core.ui.UiString
 import com.divinelink.core.ui.resources.core_ui_error_generic_description
 import com.divinelink.core.ui.resources.core_ui_error_generic_title
 import com.divinelink.core.ui.resources.core_ui_login
+import com.divinelink.core.ui.resources.core_ui_not_connected
 import com.divinelink.core.ui.resources.core_ui_offline_description
-import com.divinelink.core.ui.resources.core_ui_offline_title
 import com.divinelink.feature.user.data.resources.Res
 import com.divinelink.feature.user.data.resources.feature_user_data_empty_watchlist
 import com.divinelink.feature.user.data.resources.feature_user_data_login_watchlist_description
@@ -108,7 +108,7 @@ class UserDataScreenTest : ComposeTest() {
 
     onNodeWithTag(TestTags.Watchlist.WATCHLIST_ERROR_CONTENT).assertIsDisplayed()
     onNodeWithTag(TestTags.BLANK_SLATE).assertIsDisplayed()
-    onNodeWithText(getString(UiString.core_ui_offline_title))
+    onNodeWithText(getString(UiString.core_ui_not_connected))
       .assertIsDisplayed()
     onNodeWithText(getString(UiString.core_ui_offline_description))
       .assertIsDisplayed()


### PR DESCRIPTION
### Summary

- Clean up unused and duplicate strings
- Mark some strings that should not be translated as untranslatable 