### PR TITLE
Display external ratings even if any other rating call fails

### DIFF
--- a/app/src/androidHostTest/kotlin/com/divinelink/scenepeek/details/domain/usecase/GetMediaDetailsUseCaseTest.kt
+++ b/app/src/androidHostTest/kotlin/com/divinelink/scenepeek/details/domain/usecase/GetMediaDetailsUseCaseTest.kt
@@ -172,6 +172,7 @@ class GetMediaDetailsUseCaseTest {
 
     moviesRepository.mockCheckFavorite(555, MediaType.MOVIE, Result.success(true))
     repository.mockFetchMediaDetails(movieRequest, Result.success(movieDetails))
+    repository.mockFetchTraktRating(Result.failure(Exception()))
     val useCase = createGetMediaDetailsUseCase()
 
     useCase(movieRequest).test {

--- a/app/src/androidHostTest/kotlin/com/divinelink/scenepeek/search/domain/repository/ProdDetailsRepositoryTest.kt
+++ b/app/src/androidHostTest/kotlin/com/divinelink/scenepeek/search/domain/repository/ProdDetailsRepositoryTest.kt
@@ -681,24 +681,24 @@ class ProdDetailsRepositoryTest {
   @Test
   fun `test fetch trakt ratings with success`() = runTest {
     traktService.mockFetchRating(
-      response = TraktRatingApi(
-        rating = 8.5,
-        votes = 1_000,
+      response = Result.success(
+        TraktRatingApi(
+          rating = 8.5,
+          votes = 1_000,
+        ),
       ),
     )
 
     val response = repository.fetchTraktRating(
       mediaType = MediaType.MOVIE,
       imdbId = "tt0401729",
-    ).first()
+    )
 
-    assertThat(response).isEqualTo(
-      Result.success(
+    response shouldBe Result.success(
         RatingDetails.Score(
           voteAverage = 8.5,
           voteCount = 1_000,
         ),
-      ),
     )
   }
 

--- a/core/data/src/commonMain/kotlin/com/divinelink/core/data/details/repository/DetailsRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/divinelink/core/data/details/repository/DetailsRepository.kt
@@ -60,10 +60,10 @@ interface DetailsRepository {
 
   fun fetchExternalRatings(imdbId: String): Flow<Result<ExternalRatings?>>
 
-  fun fetchTraktRating(
+  suspend fun fetchTraktRating(
     mediaType: MediaType,
     imdbId: String,
-  ): Flow<Result<RatingDetails>>
+  ): Result<RatingDetails>
 
   fun findById(id: String): Flow<Result<MediaItem>>
 

--- a/core/data/src/commonMain/kotlin/com/divinelink/core/data/details/repository/ProdDetailsRepository.kt
+++ b/core/data/src/commonMain/kotlin/com/divinelink/core/data/details/repository/ProdDetailsRepository.kt
@@ -255,12 +255,12 @@ class ProdDetailsRepository(
     .fetchExternalRatings(imdbId = imdbId)
     .map { Result.success(it.map()) }
 
-  override fun fetchTraktRating(
+  override suspend fun fetchTraktRating(
     mediaType: MediaType,
     imdbId: String,
-  ): Flow<Result<RatingDetails>> = traktService
+  ): Result<RatingDetails> = traktService
     .fetchRating(mediaType = mediaType, imdbId = imdbId)
-    .map { Result.success(it.map()) }
+    .map { it.map() }
 
   override fun findById(id: String): Flow<Result<MediaItem>> = mediaRemote
     .findById(id)

--- a/core/domain/src/androidHostTest/kotlin/com/divinelink/core/domain/details/media/FetchAllRatingsUseCaseTest.kt
+++ b/core/domain/src/androidHostTest/kotlin/com/divinelink/core/domain/details/media/FetchAllRatingsUseCaseTest.kt
@@ -79,7 +79,7 @@ class FetchAllRatingsUseCaseTest {
       repository = repository.mock,
       dispatcher = testDispatcher,
     ).invoke(MediaDetailsFactory.FightClub()).test {
-      awaitItem().toString() shouldBe Result.failure<Exception>(Exception()).toString()
+      awaitItem() shouldBe Result.success(RatingSource.TRAKT to RatingDetails.Unavailable)
       awaitItem() shouldBe Result.success(RatingSource.TRAKT to RatingDetailsFactory.trakt())
       awaitComplete()
     }

--- a/core/domain/src/commonMain/kotlin/com/divinelink/core/domain/details/media/FetchAllRatingsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/divinelink/core/domain/details/media/FetchAllRatingsUseCase.kt
@@ -9,6 +9,7 @@ import com.divinelink.core.model.details.rating.RatingDetails
 import com.divinelink.core.model.details.rating.RatingSource
 import com.divinelink.core.model.media.MediaType
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.launch
 
@@ -31,42 +32,47 @@ class FetchAllRatingsUseCase(
 
       launch {
         if (parameters.ratingCount.ratings[RatingSource.IMDB] == RatingDetails.Initial) {
-          repository.fetchExternalRatings(imdbId).collect { result ->
-            result.fold(
-              onSuccess = { ratings ->
-                send(
-                  Result.success(RatingSource.IMDB to (ratings?.imdb ?: RatingDetails.Unavailable)),
-                )
-                send(
-                  Result.success(
-                    RatingSource.METACRITIC to (ratings?.metascore ?: RatingDetails.Unavailable),
-                  ),
-                )
-                send(
-                  Result.success(RatingSource.RT to (ratings?.rt ?: RatingDetails.Unavailable)),
-                )
-              },
-              onFailure = { error ->
-                send(Result.failure(error))
-              },
-            )
-          }
+          repository
+            .fetchExternalRatings(imdbId)
+            .catch { send(Result.success(RatingSource.TRAKT to RatingDetails.Unavailable)) }
+            .collect { result ->
+              result.fold(
+                onSuccess = { ratings ->
+                  send(
+                    Result.success(
+                      RatingSource.IMDB to (ratings?.imdb ?: RatingDetails.Unavailable),
+                    ),
+                  )
+                  send(
+                    Result.success(
+                      RatingSource.METACRITIC to (ratings?.metascore ?: RatingDetails.Unavailable),
+                    ),
+                  )
+                  send(
+                    Result.success(RatingSource.RT to (ratings?.rt ?: RatingDetails.Unavailable)),
+                  )
+                },
+                onFailure = {
+                  send(Result.success(RatingSource.TRAKT to RatingDetails.Unavailable))
+                },
+              )
+            }
         }
       }
 
       launch {
         if (parameters.ratingCount.ratings[RatingSource.TRAKT] == RatingDetails.Initial) {
           val mediaType = if (parameters is Movie) MediaType.MOVIE else MediaType.TV
-          repository.fetchTraktRating(mediaType, imdbId).collect { result ->
-            result.fold(
-              onSuccess = { traktDetails ->
-                send(Result.success(RatingSource.TRAKT to traktDetails))
+          repository
+            .fetchTraktRating(mediaType, imdbId)
+            .fold(
+              onSuccess = { result ->
+                send(Result.success(RatingSource.TRAKT to result))
               },
-              onFailure = { error ->
-                send(Result.failure(error))
+              onFailure = {
+                send(Result.success(RatingSource.TRAKT to RatingDetails.Unavailable))
               },
             )
-          }
         }
       }
     }

--- a/core/domain/src/commonMain/kotlin/com/divinelink/core/domain/details/media/GetMediaDetailsUseCase.kt
+++ b/core/domain/src/commonMain/kotlin/com/divinelink/core/domain/details/media/GetMediaDetailsUseCase.kt
@@ -180,7 +180,7 @@ open class GetMediaDetailsUseCase(
 
       if (parameters is MediaRequestApi.TV) {
         launch(dispatcher.default) {
-          repository.fetchAggregateCredits(parameters.id.toLong())
+          repository.fetchAggregateCredits(parameters.id)
             .catch { Napier.e("$it") }
             .collect { result ->
               result.onSuccess {
@@ -328,9 +328,10 @@ open class GetMediaDetailsUseCase(
     return details.imdbId?.let { id ->
       repository
         .fetchTraktRating(mediaType = mediaType, imdbId = id)
-        .catch { emit(Result.failure(it)) }
-        .firstOrNull()
-        ?.fold(
+        .fold(
+          onSuccess = { result ->
+            details.copy(ratingCount = details.ratingCount.updateRating(RatingSource.TRAKT, result))
+          },
           onFailure = {
             details.copy(
               ratingCount = details.ratingCount.updateRating(
@@ -338,9 +339,6 @@ open class GetMediaDetailsUseCase(
                 RatingDetails.Unavailable,
               ),
             )
-          },
-          onSuccess = { result ->
-            details.copy(ratingCount = details.ratingCount.updateRating(RatingSource.TRAKT, result))
           },
         )
     } ?: details

--- a/core/network/src/androidHostTest/kotlin/com/divinelink/core/network/trakt/service/ProdOMDbServiceTest.kt
+++ b/core/network/src/androidHostTest/kotlin/com/divinelink/core/network/trakt/service/ProdOMDbServiceTest.kt
@@ -3,8 +3,7 @@ package com.divinelink.core.network.trakt.service
 import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.network.trakt.model.TraktRatingApi
 import com.divinelink.core.testing.network.TestTraktClient
-import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.flow.single
+import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -48,9 +47,9 @@ class ProdTraktServiceTest {
     val response = service.fetchRating(
       mediaType = MediaType.MOVIE,
       imdbId = "tt0290978",
-    ).single()
+    )
 
-    assertThat(response).isEqualTo(
+    response shouldBe Result.success(
       TraktRatingApi(
         rating = 8.0,
         votes = 4271,

--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/TraktClient.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/client/TraktClient.kt
@@ -5,9 +5,9 @@ import com.divinelink.core.commons.provider.SecretProvider
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.plugins.defaultRequest
-import io.ktor.client.request.headers
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
+import io.ktor.http.userAgent
 
 class TraktClient(
   engine: HttpClientEngine,
@@ -19,6 +19,7 @@ class TraktClient(
     defaultRequest {
       contentType(ContentType.Application.Json)
       headers {
+        userAgent("ScenePeek/${config.versionName}")
         set("trakt-api-key", secret.traktApiKey)
         set("trakt-api-version", "2")
       }

--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/trakt/service/ProdTraktService.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/trakt/service/ProdTraktService.kt
@@ -5,18 +5,15 @@ import com.divinelink.core.network.client.TraktClient
 import com.divinelink.core.network.client.get
 import com.divinelink.core.network.trakt.model.TraktRatingApi
 import com.divinelink.core.network.trakt.util.buildTraktRatingUrl
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 
 class ProdTraktService(private val client: TraktClient) : TraktService {
 
-  override fun fetchRating(
+  override suspend fun fetchRating(
     mediaType: MediaType,
     imdbId: String,
-  ): Flow<TraktRatingApi> = flow {
+  ): Result<TraktRatingApi> = runCatching {
     val url = buildTraktRatingUrl(mediaType = mediaType, imdbId = imdbId)
 
-    val response = client.client.get<TraktRatingApi>(url)
-    emit(response)
+    client.client.get<TraktRatingApi>(url)
   }
 }

--- a/core/network/src/commonMain/kotlin/com/divinelink/core/network/trakt/service/TraktService.kt
+++ b/core/network/src/commonMain/kotlin/com/divinelink/core/network/trakt/service/TraktService.kt
@@ -2,11 +2,10 @@ package com.divinelink.core.network.trakt.service
 
 import com.divinelink.core.model.media.MediaType
 import com.divinelink.core.network.trakt.model.TraktRatingApi
-import kotlinx.coroutines.flow.Flow
 
 interface TraktService {
-  fun fetchRating(
+  suspend fun fetchRating(
     mediaType: MediaType,
     imdbId: String,
-  ): Flow<TraktRatingApi>
+  ): Result<TraktRatingApi>
 }

--- a/core/testing/src/androidMain/kotlin/com/divinelink/core/testing/repository/TestDetailsRepository.kt
+++ b/core/testing/src/androidMain/kotlin/com/divinelink/core/testing/repository/TestDetailsRepository.kt
@@ -128,11 +128,11 @@ class TestDetailsRepository {
     ).thenReturn(flowOf(response))
   }
 
-  fun mockFetchTraktRating(response: Result<RatingDetails>) {
+  suspend fun mockFetchTraktRating(response: Result<RatingDetails>) {
     whenever(
       mock.fetchTraktRating(any(), any()),
     ).thenReturn(
-      flowOf(response),
+      response,
     )
   }
 

--- a/core/testing/src/androidMain/kotlin/com/divinelink/core/testing/service/TestTraktService.kt
+++ b/core/testing/src/androidMain/kotlin/com/divinelink/core/testing/service/TestTraktService.kt
@@ -2,7 +2,6 @@ package com.divinelink.core.testing.service
 
 import com.divinelink.core.network.trakt.model.TraktRatingApi
 import com.divinelink.core.network.trakt.service.TraktService
-import kotlinx.coroutines.flow.flowOf
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -10,7 +9,7 @@ import org.mockito.kotlin.whenever
 class TestTraktService {
   val mock: TraktService = mock()
 
-  fun mockFetchRating(response: TraktRatingApi) {
-    whenever(mock.fetchRating(mediaType = any(), imdbId = any())).thenReturn(flowOf(response))
+  suspend fun mockFetchRating(response: Result<TraktRatingApi>) {
+    whenever(mock.fetchRating(mediaType = any(), imdbId = any())).thenReturn(response)
   }
 }

--- a/feature/details/src/commonMain/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
+++ b/feature/details/src/commonMain/kotlin/com/divinelink/feature/details/media/ui/DetailsViewModel.kt
@@ -78,6 +78,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
@@ -654,9 +655,13 @@ class DetailsViewModel(
   }
 
   fun onFetchAllRatings() {
-    viewModelScope.launch {
-      viewState.value.mediaDetails?.let {
-        fetchAllRatingsUseCase(it).collect { result ->
+    viewState.value.mediaDetails?.let {
+      fetchAllRatingsUseCase(it)
+        .distinctUntilChanged()
+        .catch { error ->
+          Napier.d { error.message.toString() }
+        }
+        .onEach { result ->
           result
             .onSuccess { rating ->
               _viewState.update { viewState ->
@@ -669,11 +674,9 @@ class DetailsViewModel(
                   ),
                 )
               }
-            }.onFailure { error ->
-              Napier.e("$error")
             }
         }
-      }
+        .launchIn(viewModelScope)
     }
   }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Nov 10 10:26:03 EET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Summary

Fixes an issue where if any external ratings call would fail (either from Trakt or OMDB) then none of them would be displayed.